### PR TITLE
feat: add withdrawals field to transaction events

### DIFF
--- a/input/chainsync/tx.go
+++ b/input/chainsync/tx.go
@@ -89,7 +89,7 @@ func NewTransactionEvent(
 	if len(resolvedInputs) > 0 {
 		evt.ResolvedInputs = resolvedInputs
 	}
-	if withdrawals := tx.Withdrawals() {
+	if withdrawals := tx.Withdrawals(); len(withdrawals) > 0{
 		evt.Withdrawals = make(map[string]uint64)
 		for addr, amount := range withdrawals {
 			evt.Withdrawals[addr.String()] = amount

--- a/input/chainsync/tx.go
+++ b/input/chainsync/tx.go
@@ -39,6 +39,7 @@ type TransactionEvent struct {
 	Fee             uint64                     `json:"fee"`
 	TTL             uint64                     `json:"ttl,omitempty"`
 	ResolvedInputs  []ledger.TransactionOutput `json:"resolvedInputs,omitempty"`
+	Withdrawals     map[string]uint64          `json:"withdrawals,omitempty"`
 }
 
 func NewTransactionContext(
@@ -87,6 +88,12 @@ func NewTransactionEvent(
 	}
 	if len(resolvedInputs) > 0 {
 		evt.ResolvedInputs = resolvedInputs
+	}
+	if withdrawals := tx.Withdrawals() {
+		evt.Withdrawals = make(map[string]uint64)
+		for addr, amount := range withdrawals {
+			evt.Withdrawals[addr.String()] = amount
+		}
 	}
 	return evt
 }


### PR DESCRIPTION
As title says, adds staking withdrawals information to tx events. Closes #241

Tested manually on tx hash `3cd223934d556c4f599055cad6257992d20a7b37418c7d864a987fc91109be48` and 
```yaml
intersect-point: 140137291.eef70ed5877425b4059f5c139e8ebaef4f01c3ae33aa9a788a670913daf2ce14
```
logs out:
```bash
...
"withdrawals":{"stake1u9gumv8sjecsga0frqg40l66y3arl7xnu8cj237z93csxyscsg85a":68737598}
...
```
as expected :relieved: 