### PR TITLE
fix(notify): tighten permissions to only user on icon file

### DIFF
--- a/output/notify/notify.go
+++ b/output/notify/notify.go
@@ -67,7 +67,7 @@ func (n *NotifyOutput) Start() error {
 		}
 	}
 	filename := fmt.Sprintf("%s/%s/%s", userCacheDir, "adder", "icon.png")
-	if err := os.WriteFile(filename, icon, 0666); err != nil {
+	if err := os.WriteFile(filename, icon, 0600); err != nil {
 		panic(err)
 	}
 	go func() {


### PR DESCRIPTION
Sure, it's an icon, but it's also in the user's cache directory and nobody should be poking around in there anyway.