### PR TITLE
refactor: rework chainsync bulk mode

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -41,6 +41,7 @@ linters:
     - zerologlint
   disable:
     - depguard
+    - noctx
   exclusions:
     generated: lax
     presets:

--- a/input/chainsync/options.go
+++ b/input/chainsync/options.go
@@ -102,10 +102,10 @@ func WithStatusUpdateFunc(
 }
 
 // WithBulkMode specifies whether to use the "bulk" sync mode with NtN (node-to-node). This should only be used against your own nodes for resource usage reasons
+//
+// Deprecated: this flag no longer does anything useful, as bulk mode is now the default (and only) mode of operation
 func WithBulkMode(bulkMode bool) ChainSyncOptionFunc {
-	return func(c *ChainSync) {
-		c.bulkMode = bulkMode
-	}
+	return func(c *ChainSync) {}
 }
 
 // WithKupoUrl specifies the URL for a Kupo instance that will be queried for additional information

--- a/input/chainsync/plugin.go
+++ b/input/chainsync/plugin.go
@@ -31,7 +31,6 @@ var cmdlineOptions struct {
 	address            string
 	socketPath         string
 	ntcTcp             bool
-	bulkMode           bool
 	intersectTip       bool
 	intersectPoint     string
 	includeCbor        bool
@@ -84,13 +83,6 @@ func init() {
 					Description:  "use the NtC (node-to-client) protocol over TCP, for use when exposing a node's UNIX socket via socat or similar",
 					DefaultValue: false,
 					Dest:         &(cmdlineOptions.ntcTcp),
-				},
-				{
-					Name:         "bulk-mode",
-					Type:         plugin.PluginOptionTypeBool,
-					Description:  "use the 'bulk' sync mode with NtN (node-to-node). This should only be used against your own nodes for resource usage reasons",
-					DefaultValue: false,
-					Dest:         &(cmdlineOptions.bulkMode),
 				},
 				{
 					Name:         "intersect-tip",
@@ -155,7 +147,6 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		WithAddress(cmdlineOptions.address),
 		WithSocketPath(cmdlineOptions.socketPath),
 		WithNtcTcp(cmdlineOptions.ntcTcp),
-		WithBulkMode(cmdlineOptions.bulkMode),
 		WithIncludeCbor(cmdlineOptions.includeCbor),
 		WithAutoReconnect(cmdlineOptions.autoReconnect),
 		WithKupoUrl(cmdlineOptions.kupoUrl),


### PR DESCRIPTION
This will now cache pending block points and request the full blocks in a batch. This also removes the bulk-mode config option, since it's no longer optional and the original reasons for making this optional no longer apply.

Fixes #412