### PR TITLE
ci(lint): diable noctx linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,7 +25,6 @@ linters:
     - musttag
     - nilerr
     - nilnesserr
-    - noctx
     - perfsprint
     - prealloc
     - protogetter


### PR DESCRIPTION
It was duplicated in both lists.