### PR TITLE
refactor(chainsync): always initialize kupoUrl from global config

### DIFF
--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -30,6 +30,7 @@ import (
 	"github.com/SundaeSwap-finance/kugo"
 	"github.com/SundaeSwap-finance/ogmigo/v6/ouroboros/chainsync"
 	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/adder/internal/config"
 	"github.com/blinklabs-io/adder/internal/logging"
 	"github.com/blinklabs-io/adder/plugin"
 	ouroboros "github.com/blinklabs-io/gouroboros"
@@ -97,6 +98,8 @@ func New(options ...ChainSyncOptionFunc) *ChainSync {
 		intersectPoints: []ocommon.Point{},
 		status:          &ChainSyncStatus{},
 	}
+	// Use Kupo URL from global config
+	c.kupoUrl = config.GetConfig().KupoUrl
 	for _, option := range options {
 		option(c)
 	}

--- a/input/chainsync/options.go
+++ b/input/chainsync/options.go
@@ -108,13 +108,6 @@ func WithBulkMode(bulkMode bool) ChainSyncOptionFunc {
 	return func(c *ChainSync) {}
 }
 
-// WithKupoUrl specifies the URL for a Kupo instance that will be queried for additional information
-func WithKupoUrl(kupoUrl string) ChainSyncOptionFunc {
-	return func(c *ChainSync) {
-		c.kupoUrl = kupoUrl
-	}
-}
-
 // WithDelayConfirmationCount specifies the number of confirmations (subsequent blocks) are required before an event will be emitted
 func WithDelayConfirmations(count uint) ChainSyncOptionFunc {
 	return func(c *ChainSync) {

--- a/input/chainsync/plugin.go
+++ b/input/chainsync/plugin.go
@@ -35,7 +35,6 @@ var cmdlineOptions struct {
 	intersectPoint     string
 	includeCbor        bool
 	autoReconnect      bool
-	kupoUrl            string
 	delayConfirmations uint
 }
 
@@ -113,13 +112,6 @@ func init() {
 					Dest:         &(cmdlineOptions.autoReconnect),
 				},
 				{
-					Name:         "kupo-url",
-					Type:         plugin.PluginOptionTypeString,
-					Description:  "kupo-url address",
-					DefaultValue: "",
-					Dest:         &(cmdlineOptions.kupoUrl),
-				},
-				{
 					Name:         "delay-confirmations",
 					Type:         plugin.PluginOptionTypeUint,
 					Description:  "number of confirmations required before emitting events",
@@ -149,7 +141,6 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		WithNtcTcp(cmdlineOptions.ntcTcp),
 		WithIncludeCbor(cmdlineOptions.includeCbor),
 		WithAutoReconnect(cmdlineOptions.autoReconnect),
-		WithKupoUrl(cmdlineOptions.kupoUrl),
 		WithDelayConfirmations(cmdlineOptions.delayConfirmations),
 	}
 	if cmdlineOptions.intersectPoint != "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,6 +38,7 @@ type Config struct {
 	Input      string                            `yaml:"input"   envconfig:"INPUT"`
 	Output     string                            `yaml:"output"  envconfig:"OUTPUT"`
 	Plugin     map[string]map[string]map[any]any `yaml:"plugins"`
+	KupoUrl    string                            `yaml:"kupo_url" envconfig:"KUPO_URL"`
 }
 
 type ApiConfig struct {
@@ -67,8 +68,9 @@ var globalConfig = &Config{
 		ListenAddress: "localhost",
 		ListenPort:    0,
 	},
-	Input:  DefaultInputPlugin,
-	Output: DefaultOutputPlugin,
+	Input:   DefaultInputPlugin,
+	Output:  DefaultOutputPlugin,
+	KupoUrl: "",
 }
 
 func (c *Config) Load(configFile string) error {


### PR DESCRIPTION
closes #349

BREAKING CHANGE when starting Adder with Kupo

- set KUPO_URL or kupo_url in yaml config