### PR TITLE
fix: output logging plugin and logging level in chainsync

### DIFF
--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -230,7 +230,7 @@ func (c *ChainSync) setupConnection() error {
 			if c.autoReconnect {
 				c.autoReconnectDelay = 0
 				if c.logger != nil {
-					c.logger.Info(fmt.Sprintf(
+					c.logger.Error(fmt.Sprintf(
 						"reconnecting to %s due to error: %s",
 						c.dialAddress,
 						err,
@@ -268,7 +268,7 @@ func (c *ChainSync) setupConnection() error {
 					// Restart the connection
 					if err := c.Start(); err != nil {
 						if c.logger != nil {
-							c.logger.Info(fmt.Sprintf(
+							c.logger.Error(fmt.Sprintf(
 								"reconnecting to %s due to error: %s",
 								c.dialAddress,
 								err,

--- a/output/log/log.go
+++ b/output/log/log.go
@@ -15,6 +15,7 @@
 package log
 
 import (
+	"fmt"
 	"log/slog"
 
 	"github.com/blinklabs-io/adder/event"
@@ -63,14 +64,14 @@ func (l *LogOutput) Start() error {
 			}
 			switch l.level {
 			case "info":
-				l.outputLogger.Info("", "event", evt)
+				l.outputLogger.Info("", "event", fmt.Sprintf("%+v", evt))
 			case "warn":
-				l.outputLogger.Warn("", "event", evt)
+				l.outputLogger.Warn("", "event", fmt.Sprintf("%+v", evt))
 			case "error":
-				l.outputLogger.Error("", "event", evt)
+				l.outputLogger.Error("", "event", fmt.Sprintf("%+v", evt))
 			default:
 				// Use INFO level if log level isn't recognized
-				l.outputLogger.Info("", "event", evt)
+				l.outputLogger.Info("", "event", fmt.Sprintf("%+v", evt))
 			}
 		}
 	}()


### PR DESCRIPTION
Old

```
{"timestamp":"2025-09-25T10:09:30-04:00","level":"INFO","msg":"","component":"main","plugin":"output.log","type":"event","event":"!ERROR:json: unsupported type: map[common.RedeemerKey]common.RedeemerValue"}
```

New
```
{"timestamp":"2025-09-25T10:09:30-04:00","level":"INFO","msg":"","component":"main","plugin":"output.log","type":"event","event":"{Type:chainsync.transaction Timestamp:2025-09-25 10:09:30.290397 -0400 EDT m=+679.069448459 Context:{BlockNumber:3637187 SlotNumber:92153369 TransactionHash:0fda85d322b580bfc01a6f01745d84cb5fa9688fd9ce7d9450895898547c1984 TransactionIdx:0 NetworkMagic:2} Payload:{Transaction:0x14000749088 BlockHash:4215034ed131909d8bbd6d6e0dcd3e22c263dd5d66d028c62ddafa61cdd93d21 TransactionCbor:[] Inputs:[5f4c9723437118f50363e56f61c6cffbf1e65945ad97c0cfbdbeffd2cae7d751#0 2536455370da8e6986731cb0a9f55505225e4712e9e6281815d482b79fb698a8#1 5f4c9723437118f50363e56f61c6cffbf1e65945ad97c0cfbdbeffd2cae7d751#2] Outputs:[(BabbageTransactionOutput address=addr_test1wrxqwmj2twfn5rtp6w4cvkehk0ucnkeklggcfpz76ktrsdsx47pvl amount=3000000 assets=[b6525f0993875db27b0a1c780f0e0f1678aced0de6caf0d241b61e87.=1]) (BabbageTransactionOutput address=addr_test1wrdk050fs7r9537m9wxfnqzmjsxnmud5v8le6vjh6k5jhvchuyj76 amount=3000000 assets=[b9a05feafb9a147460f8c9e6f63de66d5f3d151ddcd93d0132e90fb6.=1]) (BabbageTransactionOutput address=addr_test1zqudngxpumflu6gh45hw3tkeuzeq3vmgvr25f6y60t7n0rhvt20ehwqu594stgx7mw6855w20cxsnt5g5r7zy8j5nnuqlh5wkk amount=629284781912 assets=[af829f4472c3728307007831fa000e450883cfca4893d9ef535e8786.=1]) (BabbageTransactionOutput address=addr_test1zqudngxpumflu6gh45hw3tkeuzeq3vmgvr25f6y60t7n0rhvt20ehwqu594stgx7mw6855w20cxsnt5g5r7zy8j5nnuqlh5wkk amount=629284781912 assets=[af829f4472c3728307007831fa000e450883cfca4893d9ef535e8786.=1]) (BabbageTransactionOutput address=addr_test1zqudngxpumflu6gh45hw3tkeuzeq3vmgvr25f6y60t7n0rhvt20ehwqu594stgx7mw6855w20cxsnt5g5r7zy8j5nnuqlh5wkk amount=629284781912 assets=[af829f4472c3728307007831fa000e450883cfca4893d9ef535e8786.=1]) (BabbageTransactionOutput address=addr_test1zqudngxpumflu6gh45hw3tkeuzeq3vmgvr25f6y60t7n0rhvt20ehwqu594stgx7mw6855w20cxsnt5g5r7zy8j5nnuqlh5wkk amount=629284781914 assets=[af829f4472c3728307007831fa000e450883cfca4893d9ef535e8786.=1]) (BabbageTransactionOutput address=addr_test1qruhen60uwzpwnnr7gjs50z2v8u9zyfw6zunet4k42zrpr54mrlv55f93rs6j48wt29w90hlxt4rvpvshe55k5r9mpvqjv2wt4 amount=25519017959)] Certificates:[] ReferenceInputs:[6565119375db89d1e936e79bc8aa137ddd97ec3f4ceea2e50fcf4b9130d9ce54#0 6109a719d281b7fbb94948cc976bbd3917289731ce417128df0cc36fb01bfb63#0 036ed48c89169a9c4e475e08a6d22ea1e09ba8a6a6cfbabfa4f1deefd269652c#0 430cd77c52e58cc907fc5b2b5b70106d7931119513719539a34918c4f88a6ea7#0 6fbf4fe3bc833bde14d384c84ed8af098e9acf9417dcd07d30bc1be1e42e5537#0] Metadata:<nil> Fee:555216 TTL:92153626 ResolvedInputs:[  ] Withdrawals:map[] Witnesses:{DecodeStoreCbor:{cborData:[163 0 129 130 88 32 110 41 12 169 44 36 132 192 9 85 236 244 246 194 229 57 226 34 51 101 135 42 32 24 186 28 247 97 170 54 131 200 88 64 234 3 83 23 136 216 240 175 78 80 151 124 90 27 82 197 96 54 7 64 232 42 37 167 188 17 11 86 151 237 52 59 159 149 42 165 219 178 126 58 211 214 98 61 216 22 185 227 58 66 139 99 1 181 24 199 230 197 142 221 9 152 192 15 4 159 216 121 128 255 5 130 132 0 0 216 121 128 130 25 125 194 26 0 174 185 221 132 0 1 26 0 45 198 192 130 26 0 28 33 128 26 34 8 40 19]} VkeyWitnesses:{useTag:false items:[{StructAsArray:{_:{}} Vkey:[110 41 12 169 44 36 132 192 9 85 236 244 246 194 229 57 226 34 51 101 135 42 32 24 186 28 247 97 170 54 131 200] Signature:[234 3 83 23 136 216 240 175 78 80 151 124 90 27 82 197 96 54 7 64 232 42 37 167 188 17 11 86 151 237 52 59 159 149 42 165 219 178 126 58 211 214 98 61 216 22 185 227 58 66 139 99 1 181 24 199 230 197 142 221 9 152 192 15]}]} WsNativeScripts:{useTag:false items:[]} BootstrapWitnesses:{useTag:false items:[]} WsPlutusV1Scripts:{useTag:false items:[]} WsPlutusData:{useTag:false items:[{DecodeStoreCbor:{cborData:[216 121 128]} Data:0x140013377a0}]} WsRedeemers:{Redeemers:map[] legacyRedeemers:[{StructAsArray:{_:{}} Tag:0 Index:0 Data:{DecodeStoreCbor:{cborData:[216 121 128]} Data:0x14001337830} ExUnits:{StructAsArray:{_:{}} Memory:32194 Steps:11450845}} {StructAsArray:{_:{}} Tag:0 Index:1 Data:{DecodeStoreCbor:{cborData:[26 0 45 198 192]} Data:0x14000984310} ExUnits:{StructAsArray:{_:{}} Memory:1843584 Steps:570959891}}] legacy:true} WsPlutusV2Scripts:{useTag:false items:[]} WsPlutusV3Scripts:{useTag:false items:[]}}}}"}
```