### PR TITLE
fix: set blockfetch recv queue size to under the limit

### DIFF
--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -244,8 +244,8 @@ func (c *ChainSync) setupConnection() error {
 			blockfetch.NewConfig(
 				blockfetch.WithBlockFunc(c.handleBlockFetchBlock),
 				blockfetch.WithBatchDoneFunc(c.handleBlockFetchBatchDone),
-				// Set the recv queue size to 2x our block batch size
-				blockfetch.WithRecvQueueSize(1000),
+				// Set the recv queue size to larger than our block batch size
+				blockfetch.WithRecvQueueSize(512),
 			),
 		),
 	)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the blockfetch receive queue size to 512 to stay under the limit. It’s still larger than our batch size to keep throughput steady.

<sup>Written for commit 02abf0cc2a2537bdda358b7fbd484fdaffb66a3f. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted block synchronization queue buffer size to reduce memory overhead during data processing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->