### PR TITLE
feat(main): Use cobra for commandline handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Events are created with a simple schema.
 
 ```json
 {
-    "type": "event type",
-    "timestamp": "wall clock timestamp of event",
-    "context": "metadata about the event",
-    "payload": "the full event specific payload"
+  "type": "event type",
+  "timestamp": "wall clock timestamp of event",
+  "context": "metadata about the event",
+  "payload": "the full event specific payload"
 }
 ```
 
@@ -27,32 +27,35 @@ The chainsync input produces three event types: `block`, `rollback`, and
 `transaction`. Each type has a unique payload.
 
 block:
+
 ```json
 {
-    "context": {
-        "blockNumber": 123,
-        "slotNumber": 1234567,
-    },
-    "payload": {
-        "blockBodySize": 123,
-        "issuerVkey": "a712f81ab2eac...",
-        "blockHash": "abcd123...",
-        "blockCbor": "85828a1a000995c21..."
-    }
+  "context": {
+    "blockNumber": 123,
+    "slotNumber": 1234567
+  },
+  "payload": {
+    "blockBodySize": 123,
+    "issuerVkey": "a712f81ab2eac...",
+    "blockHash": "abcd123...",
+    "blockCbor": "85828a1a000995c21..."
+  }
 }
 ```
 
 rollback:
+
 ```json
 {
-    "payload": {
-        "blockHash": "abcd123...",
-        "slotNumber": 1234567
-    }
+  "payload": {
+    "blockHash": "abcd123...",
+    "slotNumber": 1234567
+  }
 }
 ```
 
 transaction:
+
 ```json
 {
     "context": {
@@ -105,22 +108,23 @@ Adder supports multiple configuration methods for versatility: commandline
 arguments, YAML config file, and environment variables (in that order).
 
 You can get a list of all available commandline arguments by using the
-`-h`/`-help` flag.
+`--help` flag.
 
 ```bash
-$ ./adder -h
-Usage of adder:
-  -config string
-        path to config file to load
-  -input string
-        input plugin to use, 'list' to show available (default "chainsync")
-  -input-chainsync-address string
-        specifies the TCP address of the node to connect to
+$ ./adder --help
+
+Usage:
+  adder [flags]
+
+Flags:
+      --config string                 path to config file to load
+      --input string                  input plugin to use, 'list' to show available (default "chainsync")
+      --input-chainsync-address string
+                                      specifies the TCP address of the node to connect to
 ...
-  -output string
-        output plugin to use, 'list' to show available (default "log")
-  -output-log-level string
-        specifies the log level to use (default "info")
+      --output string                 output plugin to use, 'list' to show available (default "log")
+      --output-log-level string       specifies the log level to use (default "info")
+  -h, --help                          help for adder
 ```
 
 Each commandline argument (other than `-config`) has a corresponding environment
@@ -133,7 +137,7 @@ environment variable, and `-output` has `OUTPUT`.
 Core configuration options can be set using environment variables:
 
 - `INPUT` - Input plugin to use (default: "chainsync")
-- `OUTPUT` - Output plugin to use (default: "log")  
+- `OUTPUT` - Output plugin to use (default: "log")
 - `KUPO_URL` - URL for Kupo service integration
 - `LOGGING_LEVEL` - Log level (default: "info")
 - `API_ADDRESS` - API server listen address (default: "0.0.0.0")
@@ -144,14 +148,17 @@ Core configuration options can be set using environment variables:
 Genesis configuration can also be controlled via environment variables:
 
 **Network Transition:**
+
 - `SHELLEY_TRANS_EPOCH` - Epoch number when Shelley era begins (default: 208 for mainnet)
 
 **Byron Genesis:**
+
 - `BYRON_GENESIS_END_SLOT` - End slot for Byron era
 - `BYRON_GENESIS_EPOCH_LENGTH` - Slot length of Byron epochs (default: 21600)
 - `BYRON_GENESIS_BYRON_SLOTS_PER_EPOCH` - Byron slots per epoch
 
 **Shelley Genesis:**
+
 - `SHELLEY_GENESIS_EPOCH_LENGTH` - Slot length of Shelley epochs (default: 432000)
 
 You can also specify each option in the config file.
@@ -211,7 +218,7 @@ filters will be output.
 
 ```bash
 export INPUT_CHAINSYNC_NETWORK=preview
-./adder 
+./adder
 ```
 
 Alternatively using equivalent commandline options:

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,8 @@ require (
 	github.com/gin-gonic/gin v1.11.0
 	github.com/inconshreveable/mousetrap v1.1.0
 	github.com/kelseyhightower/envconfig v1.4.0
+	github.com/spf13/cobra v1.8.1
+	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/files v1.0.1
 	github.com/swaggo/gin-swagger v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,7 @@ github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/consensys/gnark-crypto v0.19.2 h1:qrEAIXq3T4egxqiliFFoNrepkIWVEeIYwt3UL0fvS80=
 github.com/consensys/gnark-crypto v0.19.2/go.mod h1:rT23F0XSZqE0mUA0+pRtnL56IbPxs6gp4CeRsBk4XS0=
+github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v0.0.0-20171005155431-ecdeabc65495/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -218,10 +219,16 @@ github.com/quic-go/quic-go v0.54.1 h1:4ZAWm0AhCb6+hE+l5Q1NAL0iRn/ZrMwqHRGQiFwj2e
 github.com/quic-go/quic-go v0.54.1/go.mod h1:e68ZEaCdyviluZmy44P6Iey98v/Wfz6HCjQEm+l8zTY=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergeymakinen/go-bmp v1.0.0 h1:SdGTzp9WvCV0A1V0mBeaS7kQAwNLdVJbmHlqNWq0R+M=
 github.com/sergeymakinen/go-bmp v1.0.0/go.mod h1:/mxlAQZRLxSvJFNIEGGLBE/m40f3ZnUifpgVDlcUIEY=
 github.com/sergeymakinen/go-ico v1.0.0-beta.0 h1:m5qKH7uPKLdrygMWxbamVn+tl2HfiA3K6MFJw4GfZvQ=
 github.com/sergeymakinen/go-ico v1.0.0-beta.0/go.mod h1:wQ47mTczswBO5F0NoDt7O0IXgnV4Xy3ojrroMQzyhUk=
+github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
+github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
+github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/pflag v1.0.6 h1:jFzHGLGAlb3ruxLB8MhbI6A8+AQX/2eW4qeyNZXNp2o=
+github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,12 +15,12 @@
 package config
 
 import (
-	"flag"
 	"fmt"
 	"os"
 
 	"github.com/blinklabs-io/adder/plugin"
 	"github.com/kelseyhightower/envconfig"
+	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v2"
 )
 
@@ -151,8 +151,7 @@ func (c *Config) Load(configFile string) error {
 	return nil
 }
 
-func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
-	fs := flag.NewFlagSet(programName, flag.ExitOnError)
+func (c *Config) BindFlags(fs *pflag.FlagSet) error {
 	fs.StringVar(&c.ConfigFile, "config", "", "path to config file to load")
 	fs.BoolVar(&c.Version, "version", false, "show version and exit")
 	fs.StringVar(
@@ -167,13 +166,7 @@ func (c *Config) ParseCmdlineArgs(programName string, args []string) error {
 		DefaultOutputPlugin,
 		"output plugin to use, 'list' to show available",
 	)
-	if err := plugin.PopulateCmdlineOptions(fs); err != nil {
-		return err
-	}
-	if err := fs.Parse(args); err != nil {
-		return err
-	}
-	return nil
+	return plugin.PopulateCmdlineOptions(fs)
 }
 
 // GetConfig returns the global config instance

--- a/plugin/option.go
+++ b/plugin/option.go
@@ -15,11 +15,12 @@
 package plugin
 
 import (
-	"flag"
 	"fmt"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/spf13/pflag"
 )
 
 type PluginOptionType int
@@ -42,7 +43,7 @@ type PluginOption struct {
 }
 
 func (p *PluginOption) AddToFlagSet(
-	fs *flag.FlagSet,
+	fs *pflag.FlagSet,
 	pluginType string,
 	pluginName string,
 ) error {

--- a/plugin/register.go
+++ b/plugin/register.go
@@ -15,8 +15,9 @@
 package plugin
 
 import (
-	"flag"
 	"fmt"
+
+	"github.com/spf13/pflag"
 )
 
 type PluginType int
@@ -54,7 +55,7 @@ func Register(pluginEntry PluginEntry) {
 	pluginEntries = append(pluginEntries, pluginEntry)
 }
 
-func PopulateCmdlineOptions(fs *flag.FlagSet) error {
+func PopulateCmdlineOptions(fs *pflag.FlagSet) error {
 	for _, plugin := range pluginEntries {
 		for _, option := range plugin.Options {
 			if err := option.AddToFlagSet(fs, PluginTypeName(plugin.Type), plugin.Name); err != nil {


### PR DESCRIPTION
1. Replaced the custom flag-based CLI with a Cobra root command. Usage/help and shell parsing will come from Cobra.
2. Modified config/plugin flag registration to pflag.
3. Updated the README help snippet to match the new `adder --help` output.

Closes #164 



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched the CLI to a Cobra root command for consistent parsing and help output. Migrated all config/plugin flags to pflag and updated README to match the new adder --help.

- **Refactors**
  - Replaced custom FlagSet with Cobra (rootCmd, RunE).
  - Bound config and plugin options via pflag (BindFlags, PopulateCmdlineOptions).
  - Returned errors instead of exiting in runtime paths for cleaner failure handling.
  - Kept existing flag names; adds -h/--help and --version.

- **Dependencies**
  - Added github.com/spf13/cobra and github.com/spf13/pflag.

<sup>Written for commit a1cd43650149a4ce7d218b647b1514a227ae2983. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated command-line help references and formatting for clarity and consistency.

* **New Features**
  * Enhanced command-line interface with improved help output formatting and structured error handling.

* **Refactor**
  * Improved startup initialization and configuration binding for more robust error handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->