### PR TITLE
fix: prevent double close on pipeline stop

### DIFF
--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/adder/event"
+)
+
+// plugin that panics when Stop is called
+type panicPlugin struct{}
+
+func (p *panicPlugin) Start() error { return nil }
+func (p *panicPlugin) Stop() error  { panic("stop panic") }
+
+func (p *panicPlugin) ErrorChan() chan error          { return make(chan error) }
+func (p *panicPlugin) InputChan() chan<- event.Event  { return nil }
+func (p *panicPlugin) OutputChan() <-chan event.Event { return nil }
+
+// simple no-op plugin
+type noopPlugin struct{}
+
+func (n *noopPlugin) Start() error                   { return nil }
+func (n *noopPlugin) Stop() error                    { return nil }
+func (n *noopPlugin) ErrorChan() chan error          { return make(chan error) }
+func (n *noopPlugin) InputChan() chan<- event.Event  { return nil }
+func (n *noopPlugin) OutputChan() <-chan event.Event { return nil }
+
+func TestStopWithPluginPanic(t *testing.T) {
+	p := New()
+	pp := &panicPlugin{}
+	p.AddInput(pp)
+
+	// Stop should panic if plugin.Stop panics, since we don't catch panics
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when plugin.Stop panics")
+		}
+	}()
+	p.Stop()
+}
+
+func TestStopIdempotent(t *testing.T) {
+	p := New()
+	np := &noopPlugin{}
+	p.AddInput(np)
+
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on first Stop: %v", err)
+	}
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on second Stop (idempotent): %v", err)
+	}
+}


### PR DESCRIPTION




<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make pipeline.Stop safe by closing internal channels only once, preventing panics from double close during repeated or concurrent stops. Added closeOnce to guard closing errorChan, filterChan, and outputChan.

<sup>Written for commit d6757721836715fd63c39609d3f801b7149ac2f1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pipeline shutdown operations are now atomic and race-free. The stop mechanism is safe to call multiple times and from concurrent execution contexts.

* **Tests**
  * Added unit tests to verify correct behavior during pipeline shutdown, including scenarios with plugin failures and idempotent stop operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->