### PR TITLE
fix: ensure plugins cannot close channels

### DIFF
--- a/filter/chainsync/chainsync.go
+++ b/filter/chainsync/chainsync.go
@@ -26,7 +26,7 @@ import (
 )
 
 type ChainSync struct {
-	errorChan               chan error
+	errorChan               chan<- error
 	inputChan               chan event.Event
 	outputChan              chan event.Event
 	logger                  plugin.Logger
@@ -39,7 +39,6 @@ type ChainSync struct {
 // New returns a new ChainSync object with the specified options applied
 func New(options ...ChainSyncOptionFunc) *ChainSync {
 	c := &ChainSync{
-		errorChan:  make(chan error),
 		inputChan:  make(chan event.Event, 10),
 		outputChan: make(chan event.Event, 10),
 	}
@@ -332,13 +331,12 @@ func (c *ChainSync) Start() error {
 func (c *ChainSync) Stop() error {
 	close(c.inputChan)
 	close(c.outputChan)
-	close(c.errorChan)
 	return nil
 }
 
-// ErrorChan returns the filter error channel
-func (c *ChainSync) ErrorChan() chan error {
-	return c.errorChan
+// SetErrorChan sets the error channel
+func (c *ChainSync) SetErrorChan(ch chan<- error) {
+	c.errorChan = ch
 }
 
 // InputChan returns the input event channel

--- a/filter/chainsync/chainsync_test.go
+++ b/filter/chainsync/chainsync_test.go
@@ -30,9 +30,6 @@ import (
 	"github.com/blinklabs-io/adder/event"
 )
 
-// MockLogger is a mock implementation of the plugin.Logger interface
-type MockLogger struct{}
-
 // MockAddress is a mock implementation of the ledger.Address interface
 type MockAddress struct {
 	common.Address // Embed the common.Address struct
@@ -86,7 +83,7 @@ func (m MockAddress) Type() uint8 {
 	return 0
 }
 
-func (m *MockAddress) UnmarshalCBOR(data []byte) error {
+func (m *MockAddress) UnmarshalCBOR(_ []byte) error {
 	return nil
 }
 
@@ -136,14 +133,8 @@ func (m MockOutput) ToPlutusData() data.PlutusData {
 }
 
 func (m MockOutput) String() string {
-	return ""
+	return "mockOutput"
 }
-
-func (l *MockLogger) Info(msg string, args ...any)  {}
-func (l *MockLogger) Error(msg string, args ...any) {}
-func (l *MockLogger) Debug(msg string, args ...any) {}
-func (l *MockLogger) Warn(msg string, args ...any)  {}
-func (l *MockLogger) Trace(msg string, args ...any) {}
 
 func TestNewChainSync(t *testing.T) {
 	c := New()
@@ -177,18 +168,6 @@ func TestChainSync_Stop(t *testing.T) {
 	case <-c.outputChan:
 	default:
 		t.Fatalf("expected outputChan to be closed")
-	}
-	select {
-	case <-c.errorChan:
-	default:
-		t.Fatalf("expected errorChan to be closed")
-	}
-}
-
-func TestChainSync_ErrorChan(t *testing.T) {
-	c := New()
-	if c.ErrorChan() == nil {
-		t.Fatalf("expected non-nil errorChan")
 	}
 }
 
@@ -233,15 +212,7 @@ func mockStakeCredentialValue(
 	}
 }
 
-func mockStakeCredentialPtr(
-	credType uint,
-	hashBytes []byte,
-) *common.Credential {
-	cred := mockStakeCredentialValue(credType, hashBytes)
-	return &cred
-}
-
-func mockAddress(addrStr string) common.Address {
+func mockAddress(_ string) common.Address {
 	return common.Address{}
 }
 

--- a/filter/chainsync/plugin_test.go
+++ b/filter/chainsync/plugin_test.go
@@ -30,8 +30,7 @@ func TestPluginRegistration(t *testing.T) {
 	assert.NotNil(t, p, "Plugin should be registered")
 
 	// Verify that the plugin implements the Plugin interface
-	_, ok := p.(plugin.Plugin)
-	assert.True(t, ok, "Plugin should implement the Plugin interface")
+	assert.NotNil(t, p, "Plugin should implement the Plugin interface")
 }
 
 func TestPluginStartStop(t *testing.T) {
@@ -50,9 +49,6 @@ func TestPluginStartStop(t *testing.T) {
 func TestPluginChannels(t *testing.T) {
 	// Create a new plugin instance
 	p := NewFromCmdlineOptions()
-
-	// Verify that the error channel is not nil
-	assert.NotNil(t, p.ErrorChan(), "Error channel should not be nil")
 
 	// Verify that the input channel is not nil
 	assert.NotNil(t, p.InputChan(), "Input channel should not be nil")

--- a/filter/event/event.go
+++ b/filter/event/event.go
@@ -22,7 +22,7 @@ import (
 )
 
 type Event struct {
-	errorChan   chan error
+	errorChan   chan<- error
 	inputChan   chan event.Event
 	outputChan  chan event.Event
 	logger      plugin.Logger
@@ -32,7 +32,6 @@ type Event struct {
 // New returns a new Event object with the specified options applied
 func New(options ...EventOptionFunc) *Event {
 	e := &Event{
-		errorChan:  make(chan error),
 		inputChan:  make(chan event.Event, 10),
 		outputChan: make(chan event.Event, 10),
 	}
@@ -69,13 +68,12 @@ func (e *Event) Start() error {
 func (e *Event) Stop() error {
 	close(e.inputChan)
 	close(e.outputChan)
-	close(e.errorChan)
 	return nil
 }
 
-// ErrorChan returns the filter error channel
-func (e *Event) ErrorChan() chan error {
-	return e.errorChan
+// SetErrorChan sets the error channel
+func (e *Event) SetErrorChan(ch chan<- error) {
+	e.errorChan = ch
 }
 
 // InputChan returns the input event channel

--- a/output/log/log.go
+++ b/output/log/log.go
@@ -24,7 +24,7 @@ import (
 )
 
 type LogOutput struct {
-	errorChan    chan error
+	errorChan    chan<- error
 	eventChan    chan event.Event
 	logger       plugin.Logger
 	outputLogger *slog.Logger
@@ -33,7 +33,6 @@ type LogOutput struct {
 
 func New(options ...LogOptionFunc) *LogOutput {
 	l := &LogOutput{
-		errorChan: make(chan error),
 		eventChan: make(chan event.Event, 10),
 		level:     "info",
 	}
@@ -81,13 +80,12 @@ func (l *LogOutput) Start() error {
 // Stop the log output
 func (l *LogOutput) Stop() error {
 	close(l.eventChan)
-	close(l.errorChan)
 	return nil
 }
 
-// ErrorChan returns the input error channel
-func (l *LogOutput) ErrorChan() chan error {
-	return l.errorChan
+// SetErrorChan sets the error channel
+func (l *LogOutput) SetErrorChan(ch chan<- error) {
+	l.errorChan = ch
 }
 
 // InputChan returns the input event channel

--- a/output/notify/notify.go
+++ b/output/notify/notify.go
@@ -28,7 +28,7 @@ import (
 var icon []byte
 
 type NotifyOutput struct {
-	errorChan chan error
+	errorChan chan<- error
 	eventChan chan event.Event
 	logger    plugin.Logger
 	title     string
@@ -36,7 +36,6 @@ type NotifyOutput struct {
 
 func New(options ...NotifyOptionFunc) *NotifyOutput {
 	n := &NotifyOutput{
-		errorChan: make(chan error),
 		eventChan: make(chan event.Event, 10),
 		title:     "Adder",
 	}
@@ -166,13 +165,12 @@ func (n *NotifyOutput) Start() error {
 // Stop the embedded output
 func (n *NotifyOutput) Stop() error {
 	close(n.eventChan)
-	close(n.errorChan)
 	return nil
 }
 
-// ErrorChan returns the input error channel
-func (n *NotifyOutput) ErrorChan() chan error {
-	return n.errorChan
+// SetErrorChan sets the error channel
+func (n *NotifyOutput) SetErrorChan(ch chan<- error) {
+	n.errorChan = ch
 }
 
 // InputChan returns the input event channel

--- a/output/push/push.go
+++ b/output/push/push.go
@@ -32,7 +32,7 @@ import (
 )
 
 type PushOutput struct {
-	errorChan              chan error
+	errorChan              chan<- error
 	eventChan              chan event.Event
 	logger                 plugin.Logger
 	accessToken            string
@@ -54,7 +54,6 @@ type PushPayload struct {
 
 func New(options ...PushOptionFunc) *PushOutput {
 	p := &PushOutput{
-		errorChan: make(chan error),
 		eventChan: make(chan event.Event, 10),
 	}
 	for _, option := range options {
@@ -286,13 +285,12 @@ func (p *PushOutput) GetProjectId() error {
 // Stop the embedded output
 func (p *PushOutput) Stop() error {
 	close(p.eventChan)
-	close(p.errorChan)
 	return nil
 }
 
-// ErrorChan returns the input error channel
-func (p *PushOutput) ErrorChan() chan error {
-	return p.errorChan
+// SetErrorChan sets the error channel
+func (p *PushOutput) SetErrorChan(ch chan<- error) {
+	p.errorChan = ch
 }
 
 // InputChan returns the input event channel

--- a/output/webhook/webhook.go
+++ b/output/webhook/webhook.go
@@ -39,7 +39,7 @@ const (
 )
 
 type WebhookOutput struct {
-	errorChan  chan error
+	errorChan  chan<- error
 	eventChan  chan event.Event
 	logger     plugin.Logger
 	format     string
@@ -51,7 +51,6 @@ type WebhookOutput struct {
 
 func New(options ...WebhookOptionFunc) *WebhookOutput {
 	w := &WebhookOutput{
-		errorChan:  make(chan error),
 		eventChan:  make(chan event.Event, 10),
 		format:     "adder",
 		url:        "http://localhost:3000",
@@ -303,13 +302,12 @@ func (w *WebhookOutput) SendWebhook(e *event.Event) error {
 // Stop the embedded output
 func (w *WebhookOutput) Stop() error {
 	close(w.eventChan)
-	close(w.errorChan)
 	return nil
 }
 
-// ErrorChan returns the input error channel
-func (w *WebhookOutput) ErrorChan() chan error {
-	return w.errorChan
+// SetErrorChan sets the error channel
+func (w *WebhookOutput) SetErrorChan(ch chan<- error) {
+	w.errorChan = ch
 }
 
 // InputChan returns the input event channel

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,0 +1,54 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/blinklabs-io/adder/event"
+)
+
+// plugin that panics when Stop is called
+type panicPlugin struct{}
+
+func (p *panicPlugin) Start() error { return nil }
+func (p *panicPlugin) Stop() error  { panic("stop panic") }
+
+func (p *panicPlugin) SetErrorChan(chan<- error)      {}
+func (p *panicPlugin) InputChan() chan<- event.Event  { return nil }
+func (p *panicPlugin) OutputChan() <-chan event.Event { return nil }
+
+// simple no-op plugin
+type noopPlugin struct{}
+
+func (n *noopPlugin) Start() error                   { return nil }
+func (n *noopPlugin) Stop() error                    { return nil }
+func (n *noopPlugin) SetErrorChan(chan<- error)      {}
+func (n *noopPlugin) InputChan() chan<- event.Event  { return nil }
+func (n *noopPlugin) OutputChan() <-chan event.Event { return nil }
+
+func TestStopWithPluginPanic(t *testing.T) {
+	p := New()
+	pp := &panicPlugin{}
+	p.AddInput(pp)
+
+	// Stop should panic if plugin.Stop panics, since we don't catch panics
+	defer func() {
+		if r := recover(); r == nil {
+			t.Fatalf("expected panic when plugin.Stop panics")
+		}
+	}()
+	p.Stop()
+}
+
+func TestStopIdempotent(t *testing.T) {
+	p := New()
+	np := &noopPlugin{}
+	p.AddInput(np)
+
+	// Stop should be safe to call multiple times, even without prior Start
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on first Stop: %v", err)
+	}
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on second Stop (idempotent): %v", err)
+	}
+}

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -18,10 +18,13 @@ import (
 	"github.com/blinklabs-io/adder/event"
 )
 
+// Plugin represents a pluggable component in the pipeline.
+// The pipeline injects an error channel via SetErrorChan; plugins send errors but never close channels.
+// A nil error channel means "no error reporting"; plugins must handle this gracefully.
 type Plugin interface {
 	Start() error
 	Stop() error
-	ErrorChan() chan error
+	SetErrorChan(chan<- error)
 	InputChan() chan<- event.Event
 	OutputChan() <-chan event.Event
 }


### PR DESCRIPTION










<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent plugins from closing channels by making error channels send-only and moving channel ownership to the pipeline. This stabilizes shutdown and avoids panics from premature closes.

- **Refactors**
  - Plugin interface: replace ErrorChan() with SetErrorChan(chan<- error).
  - Pipeline creates per-plugin error channels, listens for errors, and closes them on stop.
  - Plugins no longer create or close error channels; they only send to the provided channel.
  - Tests updated to remove assumptions about plugin-owned error channels; added pipeline tests for Stop idempotence and panic propagation.

- **Migration**
  - Update custom plugins to implement SetErrorChan and send errors to the provided channel.
  - Remove any close(...) calls on channels inside plugins, especially error channels.
  - Stop exposing ErrorChan(); adjust callers to rely on pipeline-managed errors.

<sup>Written for commit b0ad37e39073a83d8cbff327d6362f5a8770b832. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->











<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Error handling now uses externally provided send-only error channels; components no longer create or close those channels.
  * Plugin API now accepts injected error channels and pipeline wires per-plugin error channels for isolated error propagation and centralized forwarding.

* **Tests**
  * Tests updated to match new error-channel semantics; legacy channel checks removed and new pipeline tests added for Stop behavior and idempotence.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->