### PR TITLE
fix: Failure to fetch information from Kupo prevents output

### DIFF
--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -409,7 +409,12 @@ func (c *ChainSync) handleRollForward(
 	for t, transaction := range block.Transactions() {
 		resolvedInputs, err := resolveTransactionInputs(transaction, c)
 		if err != nil {
-			return err
+			slog.Error(
+				"failed to resolve transaction inputs via Kupo, emitting without resolved inputs",
+				"err",
+				err,
+			)
+			resolvedInputs = nil
 		}
 		if t < 0 || t > math.MaxUint32 {
 			return errors.New("invalid number of transactions")
@@ -491,7 +496,12 @@ func (c *ChainSync) handleBlockFetchBlock(
 	for t, transaction := range block.Transactions() {
 		resolvedInputs, err := resolveTransactionInputs(transaction, c)
 		if err != nil {
-			return err
+			slog.Error(
+				"failed to resolve transaction inputs via Kupo, emitting without resolved inputs",
+				"err",
+				err,
+			)
+			resolvedInputs = nil
 		}
 		if t < 0 || t > math.MaxUint32 {
 			return errors.New("invalid number of transactions")


### PR DESCRIPTION
1. Made changes to emit an input event without the resolved inputs along with a log error message when kupo fails to give us data.

Closes #400 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit input events even when Kupo fails to resolve transaction inputs, logging the error and sending events without resolved inputs. Fixes #400.

- **Migration**
  - Consumers should handle nil resolvedInputs in input events.

<sup>Written for commit 45394a1f81d04726eca56f69ad9292f7bf55aa7b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction processing resilience. The system now logs errors and continues processing transactions even when input resolution fails, instead of aborting the entire flow. This ensures transaction processing remains functional in the presence of problematic inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->