### PR TITLE
fix: plugins own their error channel

### DIFF
--- a/filter/chainsync/chainsync_test.go
+++ b/filter/chainsync/chainsync_test.go
@@ -158,30 +158,36 @@ func TestChainSync_Stop(t *testing.T) {
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
-	// Check if channels are closed
-	select {
-	case <-c.inputChan:
-	default:
-		t.Fatalf("expected inputChan to be closed")
+	// Check if channels are nil after stop
+	if c.inputChan != nil {
+		t.Fatalf("expected inputChan to be nil after stop")
 	}
-	select {
-	case <-c.outputChan:
-	default:
-		t.Fatalf("expected outputChan to be closed")
+	if c.outputChan != nil {
+		t.Fatalf("expected outputChan to be nil after stop")
 	}
 }
 
 func TestChainSync_InputChan(t *testing.T) {
 	c := New()
+	err := c.Start()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer c.Stop()
 	if c.InputChan() == nil {
-		t.Fatalf("expected non-nil inputChan")
+		t.Fatalf("expected non-nil inputChan after Start()")
 	}
 }
 
 func TestChainSync_OutputChan(t *testing.T) {
 	c := New()
+	err := c.Start()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	defer c.Stop()
 	if c.OutputChan() == nil {
-		t.Fatalf("expected non-nil outputChan")
+		t.Fatalf("expected non-nil outputChan after Start()")
 	}
 }
 

--- a/filter/chainsync/plugin_test.go
+++ b/filter/chainsync/plugin_test.go
@@ -50,11 +50,24 @@ func TestPluginChannels(t *testing.T) {
 	// Create a new plugin instance
 	p := NewFromCmdlineOptions()
 
+	// Start the plugin (channels are created in Start())
+	err := p.Start()
+	assert.NoError(t, err, "Plugin should start without errors")
+	defer p.Stop()
+
 	// Verify that the input channel is not nil
-	assert.NotNil(t, p.InputChan(), "Input channel should not be nil")
+	assert.NotNil(
+		t,
+		p.InputChan(),
+		"Input channel should not be nil after Start()",
+	)
 
 	// Verify that the output channel is not nil
-	assert.NotNil(t, p.OutputChan(), "Output channel should not be nil")
+	assert.NotNil(
+		t,
+		p.OutputChan(),
+		"Output channel should not be nil after Start()",
+	)
 }
 
 func TestPluginEventProcessing(t *testing.T) {

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -1,27 +1,49 @@
 package pipeline
 
 import (
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/adder/event"
 )
 
 // plugin that panics when Stop is called
-type panicPlugin struct{}
+type panicPlugin struct {
+	errChanOnce sync.Once
+	errChan     chan error
+}
 
 func (p *panicPlugin) Start() error { return nil }
 func (p *panicPlugin) Stop() error  { panic("stop panic") }
 
-func (p *panicPlugin) SetErrorChan(chan<- error)      {}
+func (p *panicPlugin) ErrorChan() <-chan error {
+	p.errChanOnce.Do(func() {
+		if p.errChan == nil {
+			p.errChan = make(chan error)
+		}
+	})
+	return p.errChan
+}
 func (p *panicPlugin) InputChan() chan<- event.Event  { return nil }
 func (p *panicPlugin) OutputChan() <-chan event.Event { return nil }
 
 // simple no-op plugin
-type noopPlugin struct{}
+type noopPlugin struct {
+	errChanOnce sync.Once
+	errChan     chan error
+}
 
-func (n *noopPlugin) Start() error                   { return nil }
-func (n *noopPlugin) Stop() error                    { return nil }
-func (n *noopPlugin) SetErrorChan(chan<- error)      {}
+func (n *noopPlugin) Start() error { return nil }
+func (n *noopPlugin) Stop() error  { return nil }
+func (n *noopPlugin) ErrorChan() <-chan error {
+	n.errChanOnce.Do(func() {
+		if n.errChan == nil {
+			n.errChan = make(chan error)
+		}
+	})
+	return n.errChan
+}
 func (n *noopPlugin) InputChan() chan<- event.Event  { return nil }
 func (n *noopPlugin) OutputChan() <-chan event.Event { return nil }
 
@@ -50,5 +72,187 @@ func TestStopIdempotent(t *testing.T) {
 	}
 	if err := p.Stop(); err != nil {
 		t.Fatalf("unexpected error on second Stop (idempotent): %v", err)
+	}
+}
+
+func TestPipelineRestart(t *testing.T) {
+	p := New()
+	np := &noopPlugin{}
+	p.AddInput(np)
+
+	// First start
+	if err := p.Start(); err != nil {
+		t.Fatalf("unexpected error on first Start: %v", err)
+	}
+
+	// Stop
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on Stop: %v", err)
+	}
+
+	// Second start
+	if err := p.Start(); err != nil {
+		t.Fatalf("unexpected error on second Start: %v", err)
+	}
+
+	// Stop again
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on second Stop: %v", err)
+	}
+}
+
+// restartablePlugin is a plugin that properly supports restart by recreating channels
+type restartablePlugin struct {
+	errorChan  chan error
+	inputChan  chan event.Event
+	outputChan chan event.Event
+	doneChan   chan struct{}
+	stopOnce   sync.Once
+	wg         sync.WaitGroup
+	received   []event.Event
+	mu         sync.Mutex
+}
+
+func (r *restartablePlugin) Start() error {
+	r.mu.Lock()
+	r.errorChan = make(chan error)
+	r.inputChan = make(chan event.Event, 10)
+	r.outputChan = make(chan event.Event, 10)
+	r.doneChan = make(chan struct{})
+	r.stopOnce = sync.Once{}
+	r.received = nil
+	r.mu.Unlock()
+
+	r.wg.Add(1)
+	go func() {
+		defer r.wg.Done()
+		for {
+			select {
+			case <-r.doneChan:
+				return
+			case evt, ok := <-r.inputChan:
+				if !ok {
+					return
+				}
+				r.mu.Lock()
+				r.received = append(r.received, evt)
+				r.mu.Unlock()
+				select {
+				case r.outputChan <- evt:
+				case <-r.doneChan:
+					return
+				}
+			}
+		}
+	}()
+	return nil
+}
+
+func (r *restartablePlugin) Stop() error {
+	r.stopOnce.Do(func() {
+		if r.doneChan != nil {
+			close(r.doneChan)
+		}
+		// Wait for goroutine to exit before closing other channels
+		r.wg.Wait()
+		if r.inputChan != nil {
+			close(r.inputChan)
+		}
+		if r.outputChan != nil {
+			close(r.outputChan)
+		}
+		if r.errorChan != nil {
+			close(r.errorChan)
+		}
+	})
+	return nil
+}
+
+func (r *restartablePlugin) ErrorChan() <-chan error { return r.errorChan }
+
+func (r *restartablePlugin) InputChan() chan<- event.Event { return r.inputChan }
+
+func (r *restartablePlugin) OutputChan() <-chan event.Event { return r.outputChan }
+
+func (r *restartablePlugin) getReceived() []event.Event {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	result := make([]event.Event, len(r.received))
+	copy(result, r.received)
+	return result
+}
+
+// TestPipelineRestartWithEvents tests the full start -> process events -> stop -> start -> process events -> stop cycle
+func TestPipelineRestartWithEvents(t *testing.T) {
+	p := New()
+	input := &restartablePlugin{}
+	output := &restartablePlugin{}
+	p.AddInput(input)
+	p.AddOutput(output)
+
+	// First start
+	if err := p.Start(); err != nil {
+		t.Fatalf("unexpected error on first Start: %v", err)
+	}
+
+	// Send an event through the pipeline
+	evt1 := event.Event{Type: "test.event1"}
+	input.outputChan <- evt1
+
+	// Wait for event to be processed by the output plugin
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		received := output.getReceived()
+		if len(received) > 0 && received[0].Type == evt1.Type {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	received := output.getReceived()
+	if len(received) != 1 || received[0].Type != evt1.Type {
+		t.Fatalf(
+			"expected 1 event with type %s after first start, got %d events",
+			evt1.Type,
+			len(received),
+		)
+	}
+
+	// Stop
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on Stop: %v", err)
+	}
+
+	// Second start (restart)
+	if err := p.Start(); err != nil {
+		t.Fatalf("unexpected error on second Start (restart): %v", err)
+	}
+
+	// Send another event through the pipeline after restart
+	evt2 := event.Event{Type: "test.event2"}
+	input.outputChan <- evt2
+
+	// Wait for event to be processed by the output plugin
+	deadline = time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		received := output.getReceived()
+		if len(received) > 0 && received[0].Type == evt2.Type {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	received = output.getReceived()
+	if len(received) != 1 || received[0].Type != evt2.Type {
+		t.Fatalf(
+			"expected 1 event with type %s after restart, got %d events",
+			evt2.Type,
+			len(received),
+		)
+	}
+
+	// Stop again
+	if err := p.Stop(); err != nil {
+		t.Fatalf("unexpected error on second Stop: %v", err)
 	}
 }

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -19,12 +19,11 @@ import (
 )
 
 // Plugin represents a pluggable component in the pipeline.
-// The pipeline injects an error channel via SetErrorChan; plugins send errors but never close channels.
-// A nil error channel means "no error reporting"; plugins must handle this gracefully.
+// Plugins own their error channel; the pipeline reads from it.
 type Plugin interface {
 	Start() error
 	Stop() error
-	SetErrorChan(chan<- error)
+	ErrorChan() <-chan error
 	InputChan() chan<- event.Event
 	OutputChan() <-chan event.Event
 }


### PR DESCRIPTION
Closes #300 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Plugins now own their error channels and expose ErrorChan(). The pipeline reads from them, which simplifies error handling, avoids close panics, and lets the pipeline restart after Stop.

- **Refactors**
  - Replaced SetErrorChan with ErrorChan in the Plugin interface.
  - Plugins create and close their own error channels; Stop uses nil-safe closes.
  - Event channels are created lazily where needed.
  - Pipeline no longer injects error channels; it listens to each plugin’s ErrorChan and recreates its own channels on restart.
  - Updated input/filter/output plugins to follow the new pattern; added tests for restart and idempotent Stop.

- **Migration**
  - Implement ErrorChan() <-chan error in plugins and manage its lifecycle in Start/Stop.
  - Remove SetErrorChan usage and read errors via ErrorChan() instead.
  - Add nil checks before closing channels; create event channels on first use.

<sup>Written for commit bfe530a0f3f8195389c765a9e21a11728ddb300c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Safer lifecycle and channel handling with lazy initialization, guarded closures and restart-safe startup to reduce panics and races.
  * More consistent error propagation across components via unified error channels.

* **New Features**
  * Pipeline can register inputs/filters/outputs and supports stopping and restarting.
  * Components now expose their own error channels for direct propagation.

* **Bug Fixes**
  * Fixed race/closure issues around channel creation and shutdown.

* **Tests**
  * Added pipeline restart tests exercising restart and event flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->