### PR TITLE
fix(filter): guard starts and stops in cardano

### DIFF
--- a/filter/cardano/cardano_test.go
+++ b/filter/cardano/cardano_test.go
@@ -154,16 +154,13 @@ func TestCardano_Start(t *testing.T) {
 
 func TestCardano_Stop(t *testing.T) {
 	c := New()
-	err := c.Stop()
+	err := c.Start()
+	if err != nil {
+		t.Fatalf("expected no error on start, got %v", err)
+	}
+	err = c.Stop()
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
-	}
-	// Check if channels are nil after stop
-	if c.inputChan != nil {
-		t.Fatalf("expected inputChan to be nil after stop")
-	}
-	if c.outputChan != nil {
-		t.Fatalf("expected outputChan to be nil after stop")
 	}
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Guarded the Cardano filter start/stop lifecycle to prevent race conditions and panics during shutdown. This makes concurrent event processing safer.

- **Bug Fixes**
  - Added a sync.WaitGroup to track the processEvents goroutine (Add in Start, Done in processEvents).
  - Stop now closes doneChan, waits for the goroutine to exit, then closes input/output channels.
  - Updated tests to start before stopping and removed assumptions about channels being nil after stop.

<sup>Written for commit 03308c5fd36bfd520466136a327addfea767c076. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown of the Cardano filter component for more reliable termination.

* **Tests**
  * Updated Cardano shutdown tests to validate the complete Start/Stop lifecycle.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->