### PR TITLE
fix(lint): prealloc slices to appease golangci-lint

### DIFF
--- a/input/chainsync/plugin.go
+++ b/input/chainsync/plugin.go
@@ -144,8 +144,9 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		WithDelayConfirmations(cmdlineOptions.delayConfirmations),
 	}
 	if cmdlineOptions.intersectPoint != "" {
-		intersectPoints := []ocommon.Point{}
-		for point := range strings.SplitSeq(cmdlineOptions.intersectPoint, ",") {
+		pointsSlice := strings.Split(cmdlineOptions.intersectPoint, ",")
+		intersectPoints := make([]ocommon.Point, 0, len(pointsSlice))
+		for _, point := range pointsSlice {
 			intersectPointParts := strings.Split(point, ".")
 			if len(intersectPointParts) != 2 {
 				panic("invalid intersect point format")

--- a/output/webhook/webhook.go
+++ b/output/webhook/webhook.go
@@ -135,7 +135,7 @@ func formatWebhook(e *event.Event, format string) []byte {
 	case "discord":
 		var dwe DiscordWebhookEvent
 		var dme DiscordMessageEmbed
-		var dmes []*DiscordMessageEmbed
+		dmes := make([]*DiscordMessageEmbed, 0, 1)
 		var dmefs []*DiscordMessageEmbedField
 		switch e.Type {
 		case "chainsync.block":


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Preallocated slices in chainsync and webhook to satisfy golangci-lint’s prealloc rule and reduce allocations. No behavior change.

- **Refactors**
  - chainsync: split intersectPoint once, preallocate intersectPoints with exact capacity, and iterate over the slice.
  - webhook: preallocate Discord embeds slice with capacity 1.

<sup>Written for commit c1b17a21c89a502f507f1cfb59c431b19de2c2ff. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

