### PR TITLE
fix(webhook): retry logic

### DIFF
--- a/output/webhook/options.go
+++ b/output/webhook/options.go
@@ -14,9 +14,11 @@
 
 package webhook
 
-import "github.com/blinklabs-io/adder/plugin"
+import (
+	"time"
 
-// import "github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/adder/plugin"
+)
 
 type WebhookOptionFunc func(*WebhookOutput)
 
@@ -47,5 +49,20 @@ func WithBasicAuth(username, password string) WebhookOptionFunc {
 func WithFormat(format string) WebhookOptionFunc {
 	return func(o *WebhookOutput) {
 		o.format = format
+	}
+}
+
+// WithRetryConfig specifies the retry configuration for webhook delivery
+func WithRetryConfig(maxRetries int, initialBackoff, maxBackoff time.Duration) WebhookOptionFunc {
+	return func(o *WebhookOutput) {
+		if maxRetries >= 0 {
+			o.maxRetries = maxRetries
+		}
+		if initialBackoff > 0 {
+			o.initialBackoff = initialBackoff
+		}
+		if maxBackoff > 0 {
+			o.maxBackoff = maxBackoff
+		}
 	}
 }


### PR DESCRIPTION
Closes #334 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds retry with exponential backoff for webhook delivery to improve reliability and prevent lost events. Addresses #334 by handling transient failures and reporting exhausted retries.

- **Bug Fixes**
  - Retries failed webhook sends with exponential backoff and a max backoff cap.
  - Logs attempts and final failure; sends a non-blocking error to errorChan.

- **New Features**
  - Configurable retry via WithRetryConfig(maxRetries, initialBackoff, maxBackoff).
  - Defaults: 3 retries, 1s initial backoff, 30s max backoff, factor 2.0.

<sup>Written for commit 4a95a793f658e933da6aea86d754dcb1354a1554. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

