### PR TITLE
feat(api): real health check

### DIFF
--- a/api/api_test.go
+++ b/api/api_test.go
@@ -1,11 +1,13 @@
 package api_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/blinklabs-io/adder/api"
 	"github.com/blinklabs-io/adder/output/push"
@@ -33,9 +35,98 @@ func TestRouteRegistration(t *testing.T) {
 	rr := httptest.NewRecorder()
 	apiInstance.Engine().ServeHTTP(rr, req)
 
-	// Check the status code
+	// Check the status code - token doesn't exist so we expect 404
 	assert.Equal(t, http.StatusNotFound, rr.Code, "Expected status not found")
-	// You can also check the response body, headers, etc.
-	// TODO check for JSON response (#338)
-	// assert.Equal(t, `{"fcmToken":"someToken"}`, rr.Body.String())
+}
+
+func TestHealthcheckEndpoint(t *testing.T) {
+	// Initialize the API and set it to debug mode for testing
+	apiInstance := api.New(true)
+
+	// Create a test request to the healthcheck endpoint
+	req, err := http.NewRequest(http.MethodGet, "/healthcheck", nil)
+	require.NoError(t, err)
+
+	// Record the response
+	rr := httptest.NewRecorder()
+	apiInstance.Engine().ServeHTTP(rr, req)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, rr.Code, "Expected status OK")
+
+	// Parse and validate JSON response
+	var response map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	require.NoError(t, err, "Response should be valid JSON")
+
+	// Check that the "failed" field exists and is false
+	failed, exists := response["failed"]
+	assert.True(t, exists, "Response should contain 'failed' field")
+	assert.Equal(t, false, failed, "Expected 'failed' to be false")
+}
+
+func TestPingEndpoint(t *testing.T) {
+	// Initialize the API and set it to debug mode for testing
+	apiInstance := api.New(true)
+
+	// Create a test request to the ping endpoint
+	req, err := http.NewRequest(http.MethodGet, "/ping", nil)
+	require.NoError(t, err)
+
+	// Record the response
+	rr := httptest.NewRecorder()
+	apiInstance.Engine().ServeHTTP(rr, req)
+
+	// Check the status code
+	assert.Equal(t, http.StatusOK, rr.Code, "Expected status OK")
+
+	// Check response body
+	assert.Equal(t, "pong", rr.Body.String(), "Expected 'pong' response")
+}
+
+// mockHealthChecker implements api.HealthChecker for testing
+type mockHealthChecker struct {
+	running bool
+}
+
+func (m *mockHealthChecker) IsRunning() bool {
+	return m.running
+}
+
+func TestHealthcheckWithUnhealthyPipeline(t *testing.T) {
+	// Initialize the API and set it to debug mode for testing
+	apiInstance := api.New(true)
+
+	// Clean up health checkers after test to prevent state leakage
+	t.Cleanup(api.ResetHealthCheckers)
+
+	// Register a mock health checker that reports as not running
+	mock := &mockHealthChecker{running: false}
+	api.RegisterHealthChecker(mock)
+
+	// Create a test request to the healthcheck endpoint
+	req, err := http.NewRequest(http.MethodGet, "/healthcheck", nil)
+	require.NoError(t, err)
+
+	// Record the response
+	rr := httptest.NewRecorder()
+	apiInstance.Engine().ServeHTTP(rr, req)
+
+	// Check the status code - should be 503 Service Unavailable
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code, "Expected status Service Unavailable")
+
+	// Parse and validate JSON response
+	var response map[string]interface{}
+	err = json.Unmarshal(rr.Body.Bytes(), &response)
+	require.NoError(t, err, "Response should be valid JSON")
+
+	// Check that the "failed" field exists and is true
+	failed, exists := response["failed"]
+	assert.True(t, exists, "Response should contain 'failed' field")
+	assert.Equal(t, true, failed, "Expected 'failed' to be true")
+
+	// Check that the "reason" field exists
+	reason, exists := response["reason"]
+	assert.True(t, exists, "Response should contain 'reason' field")
+	assert.Equal(t, "pipeline is not running", reason, "Expected reason to explain why unhealthy")
 }

--- a/cmd/adder/main.go
+++ b/cmd/adder/main.go
@@ -168,6 +168,9 @@ func run() error {
 	// Create pipeline
 	pipe := pipeline.New()
 
+	// Register pipeline as health checker for API
+	api.RegisterHealthChecker(pipe)
+
 	// Configure input
 	input := plugin.GetPlugin(plugin.PluginTypeInput, cfg.Input)
 	if input == nil {


### PR DESCRIPTION
closes #337 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a real /healthcheck that reflects pipeline status. Returns 200 when running and 503 with a reason when not.

- **New Features**
  - Introduced a HealthChecker interface and registry; pipeline implements IsRunning.
  - /healthcheck queries registered checkers; reports healthy if none are registered.
  - Registered the pipeline as the API health checker in cmd/adder.
  - Added tests for healthcheck, ping, and route registration.

<sup>Written for commit 1af5f4de904c3d963671393f221c5e3aaa9797be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Health check endpoint now dynamically monitors all service components
  * API returns HTTP 503 (Service Unavailable) when components are unhealthy
  * Pipeline status is now integrated with the health monitoring system
  * Enhanced visibility into real-time service health and reliability

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->