### PR TITLE
fix: error instead of panic

### DIFF
--- a/input/chainsync/chainsync_test.go
+++ b/input/chainsync/chainsync_test.go
@@ -91,6 +91,51 @@ func TestHandleRollBackward(t *testing.T) {
 	assert.Equal(t, uint64(5), c.status.EpochNumber)
 }
 
+func TestInvalidIntersectPointFormat(t *testing.T) {
+	// Save original value
+	originalIntersectPoint := cmdlineOptions.intersectPoint
+	defer func() {
+		cmdlineOptions.intersectPoint = originalIntersectPoint
+	}()
+
+	tests := []struct {
+		name           string
+		intersectPoint string
+	}{
+		{
+			name:           "missing dot separator",
+			intersectPoint: "12345abc123",
+		},
+		{
+			name:           "too many parts",
+			intersectPoint: "12345.abc123.extra",
+		},
+		{
+			name:           "non-numeric slot",
+			intersectPoint: "notanumber.abc123def456",
+		},
+		{
+			name:           "invalid hex hash",
+			intersectPoint: "12345.notvalidhex!@#",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmdlineOptions.intersectPoint = tt.intersectPoint
+			p := NewFromCmdlineOptions()
+			assert.Nil(t, p, "expected nil plugin for invalid intersect point: %s", tt.intersectPoint)
+		})
+	}
+
+	// Test valid intersect point returns non-nil
+	t.Run("valid intersect point", func(t *testing.T) {
+		cmdlineOptions.intersectPoint = "12345.abcdef0123456789"
+		p := NewFromCmdlineOptions()
+		assert.NotNil(t, p, "expected non-nil plugin for valid intersect point")
+	})
+}
+
 func TestGetKupoClient(t *testing.T) {
 	// Setup test server
 	ts := httptest.NewServer(

--- a/input/chainsync/plugin.go
+++ b/input/chainsync/plugin.go
@@ -149,7 +149,11 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		for _, point := range pointsSlice {
 			intersectPointParts := strings.Split(point, ".")
 			if len(intersectPointParts) != 2 {
-				panic("invalid intersect point format")
+				logging.GetLogger().Error(
+					"invalid intersect point format: expected '<slot>.<hash>'",
+					"point", point,
+				)
+				return nil
 			}
 			intersectSlot, err := strconv.ParseUint(
 				intersectPointParts[0],
@@ -157,11 +161,21 @@ func NewFromCmdlineOptions() plugin.Plugin {
 				64,
 			)
 			if err != nil {
-				panic("invalid intersect point format")
+				logging.GetLogger().Error(
+					"invalid intersect point format: slot must be a number",
+					"point", point,
+					"error", err,
+				)
+				return nil
 			}
 			intersectHashBytes, err := hex.DecodeString(intersectPointParts[1])
 			if err != nil {
-				panic("invalid intersect point format")
+				logging.GetLogger().Error(
+					"invalid intersect point format: hash must be valid hex",
+					"point", point,
+					"error", err,
+				)
+				return nil
 			}
 			intersectPoints = append(
 				intersectPoints,

--- a/output/notify/notify_test.go
+++ b/output/notify/notify_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notify
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNotifyOutputNew(t *testing.T) {
+	t.Run("default title", func(t *testing.T) {
+		n := New()
+		assert.Equal(t, "Adder", n.title)
+	})
+
+	t.Run("custom title", func(t *testing.T) {
+		n := New(WithTitle("Custom Title"))
+		assert.Equal(t, "Custom Title", n.title)
+	})
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop panics and handle errors properly in chainsync and notifications to prevent crashes. Adds validation and logging for bad inputs and runtime failures.

- **Bug Fixes**
  - Chainsync plugin: validate intersectPoint as "<slot>.<hash>"; log and return nil on invalid format, non-numeric slot, or bad hex.
  - Notify output: return errors for cache dir and icon write; log and continue on notification send failures; guard against nil payload/context in block, rollback, and transaction events.
  - Tests: add cases for invalid intersectPoint formats and NotifyOutput title configuration.

<sup>Written for commit cd97adbb3f083506ac0aa06db6ce54ba4c01a61d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for invalid configuration inputs—application now logs errors gracefully instead of crashing.
  * Enhanced error logging for notification delivery failures.

* **Tests**
  * Added test suites for configuration parsing and notification features.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->