### PR TITLE
chore(deps): gouroboros 0.149.0

### DIFF
--- a/event/tx.go
+++ b/event/tx.go
@@ -70,7 +70,7 @@ func NewTransactionEvent(
 		BlockHash:   block.Hash().String(),
 		Inputs:      tx.Inputs(),
 		Outputs:     tx.Outputs(),
-		Fee:         tx.Fee(),
+		Fee:         tx.Fee().Uint64(),
 		Witnesses:   tx.Witnesses(),
 	}
 	if includeCbor {
@@ -94,7 +94,7 @@ func NewTransactionEvent(
 	if withdrawals := tx.Withdrawals(); len(withdrawals) > 0 {
 		evt.Withdrawals = make(map[string]uint64)
 		for addr, amount := range withdrawals {
-			evt.Withdrawals[addr.String()] = amount
+			evt.Withdrawals[addr.String()] = amount.Uint64()
 		}
 	}
 	return evt

--- a/filter/cardano/cardano_test.go
+++ b/filter/cardano/cardano_test.go
@@ -16,6 +16,7 @@ package cardano
 import (
 	"bytes"
 	"encoding/hex"
+	"math/big"
 	"testing"
 	"time"
 
@@ -100,8 +101,8 @@ func (m MockOutput) Address() ledger.Address {
 	return m.address
 }
 
-func (m MockOutput) Amount() uint64 {
-	return m.amount
+func (m MockOutput) Amount() *big.Int {
+	return big.NewInt(int64(m.amount))
 }
 
 func (m MockOutput) Assets() *common.MultiAsset[common.MultiAssetTypeOutput] {
@@ -328,7 +329,7 @@ func TestFilterByPolicyId(t *testing.T) {
 	)
 	assetName := cbor.NewByteString([]byte("asset1"))
 	assetsData[policyId] = map[cbor.ByteString]common.MultiAssetTypeOutput{
-		assetName: 1, // Add asset with quantity 1
+		assetName: big.NewInt(1), // Add asset with quantity 1
 	}
 	assets := common.NewMultiAsset(assetsData)
 
@@ -381,7 +382,7 @@ func TestFilterByAssetFingerprint(t *testing.T) {
 	)
 	assetName := cbor.NewByteString([]byte("asset1"))
 	assetsData[policyId] = map[cbor.ByteString]common.MultiAssetTypeOutput{
-		assetName: 1, // Add asset with quantity 1
+		assetName: big.NewInt(1), // Add asset with quantity 1
 	}
 	assets := common.NewMultiAsset(assetsData)
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.4
 require (
 	github.com/SundaeSwap-finance/kugo v1.3.0
 	github.com/SundaeSwap-finance/ogmigo/v6 v6.2.0
-	github.com/blinklabs-io/gouroboros v0.146.0
+	github.com/blinklabs-io/gouroboros v0.149.0
 	github.com/blinklabs-io/plutigo v0.0.20
 	github.com/btcsuite/btcd/btcutil v1.1.6
 	github.com/gen2brain/beeep v0.11.2

--- a/go.sum
+++ b/go.sum
@@ -17,8 +17,8 @@ github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk
 github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
 github.com/bits-and-blooms/bitset v1.20.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
-github.com/blinklabs-io/gouroboros v0.146.0 h1:bZD6GAbHpTRhaUEDFuD+s21eZwdAwWBJ5w5ebBRJKLk=
-github.com/blinklabs-io/gouroboros v0.146.0/go.mod h1:qRfnn0az84aaPjsvtQK52yoApww0bxQsMu9LJgQ1ftg=
+github.com/blinklabs-io/gouroboros v0.149.0 h1:Kgnnn6l/ogwdOwppqRzZi8EGtNu0B+/4hjvkgSL/Wes=
+github.com/blinklabs-io/gouroboros v0.149.0/go.mod h1:UqNKi2y70+0s+0QxSwox+pdB++lq2RqUSWtErngs8NQ=
 github.com/blinklabs-io/ouroboros-mock v0.4.0 h1:ppOcTMnC/2f5rYYSlvNqcGfAQOIpMCSDUrNh9K6a4mY=
 github.com/blinklabs-io/ouroboros-mock v0.4.0/go.mod h1:e+Kck8bmdOuaN7IfkbVvbqAVlskXNXB95oHI3YlFG5g=
 github.com/blinklabs-io/plutigo v0.0.20 h1:WLHwEOCdquQgcfjVrWpgxjLQ7GG2vXFAq6/LWtsXutg=

--- a/input/chainsync/transaction_output_test.go
+++ b/input/chainsync/transaction_output_test.go
@@ -16,6 +16,7 @@ package chainsync
 
 import (
 	"encoding/json"
+	"math/big"
 	"testing"
 
 	"github.com/blinklabs-io/gouroboros/cbor"
@@ -34,9 +35,9 @@ func TestResolvedTransactionOutput_MarshalJSON(t *testing.T) {
 
 	// Create assets for the resolved output
 	assets := common.NewMultiAsset(
-		map[common.Blake2b224]map[cbor.ByteString]uint64{
+		map[common.Blake2b224]map[cbor.ByteString]common.MultiAssetTypeOutput{
 			common.NewBlake2b224([]byte("policy1")): {
-				cbor.NewByteString([]byte("TokenA")): 100,
+				cbor.NewByteString([]byte("TokenA")): big.NewInt(100),
 			},
 		},
 	)
@@ -55,6 +56,7 @@ func TestResolvedTransactionOutput_MarshalJSON(t *testing.T) {
 	}
 
 	// Expected JSON string
+	// Note: *big.Int serializes to a string in JSON
 	expectedJSON := `{
       "address":"addr_test1wq5yehcpw4e3r32rltrww40e6ezdckr9v9l0ehptsxeynlg630pts",
       "amount":2000000,
@@ -64,7 +66,7 @@ func TestResolvedTransactionOutput_MarshalJSON(t *testing.T) {
               "nameHex":"546f6b656e41",
               "policyId":"706f6c69637931000000000000000000000000000000000000000000",
               "fingerprint":"asset174ghjk04g2dpjv8zuw6s99rm09wmfvmgtfl84n",
-              "amount":100
+              "amount":"100"
           }
       ]
   }`


### PR DESCRIPTION
Closes #585 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade gouroboros to v0.149.0 and align our Cardano transaction output and event code with upstream bigint types for asset amounts. This supports larger values and updates JSON serialization for assets.

- **Dependencies**
  - Bumped github.com/blinklabs-io/gouroboros to v0.149.0.

- **Migration**
  - TransactionOutput.Amount() now returns *big.Int, and MultiAsset uses MultiAssetTypeOutput. Update consumers and tests.
  - Asset quantities serialize as strings in JSON. Adjust parsers accordingly.
  - Fees and withdrawals are read as bigint but emitted as uint64 in events, so existing event consumers remain unchanged.

<sup>Written for commit c60c387a067c6163abaf4ef34f3578038fc7857b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced numeric handling for transaction amounts and assets using arbitrary-precision arithmetic to improve calculation accuracy.

* **Chores**
  * Updated gouroboros library dependency to v0.149.0.

* **Tests**
  * Updated test cases and mocks to align with internal numeric type changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->