### PR TITLE
feat(filter): support cardano dreps

### DIFF
--- a/filter/cardano/filter_types.go
+++ b/filter/cardano/filter_types.go
@@ -20,11 +20,13 @@ type filterSet struct {
 	pools     *poolFilter
 	policies  *policyFilter
 	assets    *assetFilter
+	dreps     *drepFilter
 
 	hasAddressFilter bool
 	hasPoolFilter    bool
 	hasPolicyFilter  bool
 	hasAssetFilter   bool
+	hasDRepFilter    bool
 }
 
 // addressFilter holds pre-computed address data for O(1) lookups
@@ -49,4 +51,11 @@ type policyFilter struct {
 // assetFilter holds asset fingerprints for O(1) lookup
 type assetFilter struct {
 	fingerprints map[string]struct{}
+}
+
+// drepFilter holds pre-computed DRep ID data for O(1) lookups
+type drepFilter struct {
+	hexDRepIds    map[string]struct{} // DRep IDs in hex format (primary lookup)
+	bech32DRepIds map[string]struct{} // DRep IDs in bech32 format (drep1xxx, drep_script1xxx)
+	hexToBech32   map[string]string   // Maps hex -> bech32 for reference
 }


### PR DESCRIPTION
Closes #488 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DRep filtering to the Cardano filter for transactions and governance events so consumers can subscribe to DRep-specific activity.

- **New Features**
  - Filters TransactionEvent certificates and voting procedures that reference specified DRep IDs.
  - Filters GovernanceEvent DRep certificates, vote delegations, and DRep votes.
  - New WithDRepIds option accepts hex or bech32 (drep/drep_script), with precomputed variants for O(1) lookups.

<sup>Written for commit 3777d273ff620de146b516d3d09d26f3d1bb492e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

