### PR TITLE
feat(filter): preprocess params in cardano plugin

### DIFF
--- a/filter/cardano/cardano.go
+++ b/filter/cardano/cardano.go
@@ -16,7 +16,6 @@ package cardano
 
 import (
 	"bytes"
-	"encoding/hex"
 	"sync"
 
 	"github.com/blinklabs-io/adder/event"
@@ -340,9 +339,8 @@ func (c *Cardano) matchDRepFilterTx(te event.TransactionEvent) bool {
 		}
 
 		if drepHash != nil {
-			// O(1) hex map lookup
-			hexStr := hex.EncodeToString(drepHash)
-			if _, exists := c.filterSet.dreps.hexDRepIds[hexStr]; exists {
+			// O(1) lookup using byte string key (no encoding needed)
+			if _, exists := c.filterSet.dreps.bytesLookup[string(drepHash)]; exists {
 				return true
 			}
 		}
@@ -354,9 +352,8 @@ func (c *Cardano) matchDRepFilterTx(te event.TransactionEvent) bool {
 			if voter.Type == common.VoterTypeDRepKeyHash ||
 				voter.Type == common.VoterTypeDRepScriptHash {
 				voterHash := voter.Hash[:]
-				// O(1) hex map lookup
-				hexStr := hex.EncodeToString(voterHash)
-				if _, exists := c.filterSet.dreps.hexDRepIds[hexStr]; exists {
+				// O(1) lookup using byte string key (no encoding needed)
+				if _, exists := c.filterSet.dreps.bytesLookup[string(voterHash)]; exists {
 					return true
 				}
 			}
@@ -382,9 +379,8 @@ func (c *Cardano) matchPoolFilterTx(te event.TransactionEvent) bool {
 			continue
 		}
 
-		// O(1) hex map lookup
-		hexStr := hex.EncodeToString(poolKeyHash)
-		if _, exists := c.filterSet.pools.hexPoolIds[hexStr]; exists {
+		// O(1) lookup using byte string key (no encoding needed)
+		if _, exists := c.filterSet.pools.bytesLookup[string(poolKeyHash)]; exists {
 			return true
 		}
 	}

--- a/filter/cardano/filter_types.go
+++ b/filter/cardano/filter_types.go
@@ -42,6 +42,7 @@ type poolFilter struct {
 	bech32PoolIds map[string]struct{} // Pool IDs in bech32 format (pool1xxx)
 	hexToBech32   map[string]string   // Maps hex -> bech32
 	bytesPoolIds  map[string][]byte   // Pre-computed byte slices for direct comparison (hex string -> bytes)
+	bytesLookup   map[string]struct{} // Byte string keys for O(1) lookup without hex encoding
 }
 
 // policyFilter holds policy IDs for O(1) lookup
@@ -60,4 +61,5 @@ type drepFilter struct {
 	bech32DRepIds map[string]struct{} // DRep IDs in bech32 format (drep1xxx, drep_script1xxx)
 	hexToBech32   map[string]string   // Maps hex -> bech32 for reference
 	bytesDRepIds  map[string][]byte   // Pre-computed byte slices for direct comparison (hex string -> bytes)
+	bytesLookup   map[string]struct{} // Byte string keys for O(1) lookup without hex encoding
 }

--- a/filter/cardano/option.go
+++ b/filter/cardano/option.go
@@ -68,6 +68,7 @@ func WithPoolIds(poolIds []string) CardanoOptionFunc {
 				bech32PoolIds: make(map[string]struct{}),
 				hexToBech32:   make(map[string]string),
 				bytesPoolIds:  make(map[string][]byte),
+				bytesLookup:   make(map[string]struct{}),
 			}
 		}
 
@@ -82,7 +83,8 @@ func WithPoolIds(poolIds []string) CardanoOptionFunc {
 						c.filterSet.pools.hexPoolIds[hexId] = struct{}{}
 						c.filterSet.pools.hexToBech32[hexId] = poolId
 						// Pre-compute byte slice for direct comparison
-						c.filterSet.pools.bytesPoolIds[hexId] = decoded
+						c.filterSet.pools.bytesPoolIds[hexId] = decoded // Store as byte string for O(1) lookup without encoding
+						c.filterSet.pools.bytesLookup[string(decoded)] = struct{}{}
 					}
 				}
 			} else {
@@ -91,6 +93,8 @@ func WithPoolIds(poolIds []string) CardanoOptionFunc {
 				if hexBytes, err := hex.DecodeString(poolId); err == nil {
 					// Pre-compute byte slice for direct comparison
 					c.filterSet.pools.bytesPoolIds[poolId] = hexBytes
+					// Store as byte string for O(1) lookup without encoding
+					c.filterSet.pools.bytesLookup[string(hexBytes)] = struct{}{}
 					if convData, err := bech32.ConvertBits(hexBytes, 8, 5, true); err == nil {
 						if encoded, err := bech32.Encode("pool", convData); err == nil {
 							c.filterSet.pools.bech32PoolIds[encoded] = struct{}{}
@@ -143,6 +147,7 @@ func WithDRepIds(drepIds []string) CardanoOptionFunc {
 				bech32DRepIds: make(map[string]struct{}),
 				hexToBech32:   make(map[string]string),
 				bytesDRepIds:  make(map[string][]byte),
+				bytesLookup:   make(map[string]struct{}),
 			}
 		}
 
@@ -161,7 +166,8 @@ func WithDRepIds(drepIds []string) CardanoOptionFunc {
 						c.filterSet.dreps.hexDRepIds[hexId] = struct{}{}
 						c.filterSet.dreps.hexToBech32[hexId] = drepId
 						// Pre-compute byte slice for direct comparison
-						c.filterSet.dreps.bytesDRepIds[hexId] = decoded
+						c.filterSet.dreps.bytesDRepIds[hexId] = decoded // Store as byte string for O(1) lookup without encoding
+						c.filterSet.dreps.bytesLookup[string(decoded)] = struct{}{}
 					}
 				}
 			} else {
@@ -171,6 +177,8 @@ func WithDRepIds(drepIds []string) CardanoOptionFunc {
 				if hexBytes, err := hex.DecodeString(drepId); err == nil {
 					// Pre-compute byte slice for direct comparison
 					c.filterSet.dreps.bytesDRepIds[drepId] = hexBytes
+					// Store as byte string for O(1) lookup without encoding
+					c.filterSet.dreps.bytesLookup[string(hexBytes)] = struct{}{}
 					if convData, err := bech32.ConvertBits(hexBytes, 8, 5, true); err == nil {
 						// Store as key hash version
 						if encoded, err := bech32.Encode("drep", convData); err == nil {


### PR DESCRIPTION
This pull request optimizes how pool and DRep ID filters are matched in the Cardano filter logic by switching from hex string comparisons to direct byte slice comparisons. This improves performance by enabling O(1) lookups using pre-computed byte arrays, reducing unnecessary encoding/decoding overhead. The changes also update the filter data structures to store these pre-computed byte slices during initialization.

Closes #336 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preprocessed Cardano pool and DRep filter IDs and switched matching to O(1) byte-key lookups to skip hex encoding. Removed the pool hexToBech32 path. Closes #336.

- **Refactors**
  - Added bytesPoolIds/bytesDRepIds and bytesLookup; populated in WithPoolIds/WithDRepIds for direct byte comparisons.
  - Replaced hex map checks with bytesLookup in DRep voter/cert and pool cert matchers.

<sup>Written for commit d6bb5a4b49aeb4d2afb116a2ab5af9ddd53edec7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Cardano filtering performance for DRep and pool identification by adding faster precomputed lookups and streamlining matching paths, yielding quicker matching and lower processing overhead while preserving behavior and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->