### PR TITLE
feat(logging): split application/output logs using stderr/stdout

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,43 @@ transaction:
 }
 ```
 
-Each event is output individually. The log output prints each event to stdout
-using Go's standard `slog` logging library.
+Each event is output individually. The log output supports two formats:
+
+- **text** (default) — human-readable, one line per event:
+
+  ```text
+  2026-02-07 09:18:40 BLOCK        slot=12345678  block=9876543  hash=abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234 era=Conway  txs=5 size=1234
+  2026-02-07 09:18:41 TX           slot=12345678  block=9876543  tx=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef fee=180000 inputs=2 outputs=3
+  2026-02-07 09:18:42 ROLLBACK     slot=12345678  hash=aabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccddaabbccdd
+  2026-02-07 09:18:43 GOVERNANCE   slot=12345678  block=9876543  tx=1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd proposals=1 votes=2 certs=1
+  ```
+
+- **json** — newline-delimited JSON, one JSON object per event (suitable for
+  piping to `jq` or other tooling):
+
+  ```json
+  {"type":"chainsync.block","timestamp":"2026-02-07T09:18:40Z","context":{"blockNumber":9876543,"slotNumber":12345678},"payload":{"blockHash":"abc12345..."}}
+  ```
+
+Select the format with `--output-log-format`:
+
+```bash
+adder --output-log-format json
+```
+
+Event data is written to **stdout** and application logs are written to
+**stderr**. This means you can capture only event output:
+
+```bash
+# Save events to a file, see app logs in terminal
+adder > events.txt
+
+# Pipe events to jq, suppress app logs
+adder --output-log-format json 2>/dev/null | jq .
+
+# See only app logs, discard event data
+adder > /dev/null
+```
 
 ## Configuration
 
@@ -123,6 +158,7 @@ Flags:
                                       specifies the TCP address of the node to connect to
 ...
       --output string                 output plugin to use, 'list' to show available (default "log")
+      --output-log-format string      output format: "text" or "json" (default "text")
       --output-log-level string       specifies the log level to use (default "info")
   -h, --help                          help for adder
 ```
@@ -181,6 +217,7 @@ plugins:
   output:
     log:
       level: info
+      format: text
 ```
 
 ## Filtering

--- a/internal/logging/kugoCustomLogger.go
+++ b/internal/logging/kugoCustomLogger.go
@@ -63,8 +63,8 @@ func convertKVs(kvs []ogmigo.KeyValue) []any {
 }
 
 func NewKugoCustomLogger(level LogLevel) *KugoCustomLogger {
-	// Create a new slog logger that logs to stdout using JSON format
-	handler := slog.NewJSONHandler(os.Stdout, nil)
+	// Create a new slog logger that logs to stderr using JSON format
+	handler := slog.NewJSONHandler(os.Stderr, nil)
 	logger := slog.New(handler)
 
 	return &KugoCustomLogger{

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -24,7 +24,7 @@ import (
 
 // defaultLogger returns a non-nil logger so globalLogger is never nil at declaration (satisfies nilaway).
 func defaultLogger() *slog.Logger {
-	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	return slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		Level: slog.LevelInfo,
 	})).With("component", "main")
 }
@@ -47,7 +47,7 @@ func Configure() {
 		level = slog.LevelInfo
 	}
 
-	handler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+	handler := slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{
 		ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
 			if a.Key == slog.TimeKey {
 				// Format the time attribute to use RFC3339 or your custom format

--- a/output/log/log_test.go
+++ b/output/log/log_test.go
@@ -1,0 +1,306 @@
+// Copyright 2025 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package log
+
+import (
+	"encoding/json"
+	"io"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewDefaults(t *testing.T) {
+	l := New()
+	assert.Equal(t, FormatText, l.format)
+}
+
+func TestNewWithOptions(t *testing.T) {
+	l := New(
+		WithFormat(FormatJSON),
+	)
+	assert.Equal(t, FormatJSON, l.format)
+}
+
+func TestFormatJSONOutput(t *testing.T) {
+	// Capture stdout
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	l := New(WithFormat(FormatJSON))
+	require.NoError(t, l.Start())
+
+	testEvent := event.New(
+		"chainsync.block",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		map[string]any{"blockNumber": 12345},
+		map[string]any{"hash": "abc123"},
+	)
+
+	l.InputChan() <- testEvent
+	require.NoError(t, l.Stop())
+
+	// Read captured output
+	w.Close()
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	// Verify it's valid JSON
+	line := strings.TrimSpace(string(output))
+	assert.NotEmpty(t, line)
+
+	var parsed event.Event
+	err = json.Unmarshal([]byte(line), &parsed)
+	require.NoError(t, err, "output should be valid JSON: %s", line)
+
+	assert.Equal(t, "chainsync.block", parsed.Type)
+	assert.Equal(
+		t,
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		parsed.Timestamp,
+	)
+}
+
+func TestFormatJSONNoSlogWrapper(t *testing.T) {
+	// Verify JSON output does NOT contain slog fields like "level" or "msg"
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	l := New(WithFormat(FormatJSON))
+	require.NoError(t, l.Start())
+
+	testEvent := event.New(
+		"chainsync.transaction",
+		time.Now(),
+		nil,
+		map[string]any{"fee": 200000},
+	)
+
+	l.InputChan() <- testEvent
+	require.NoError(t, l.Stop())
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(output))
+
+	// Should NOT have slog envelope fields
+	var raw map[string]any
+	require.NoError(t, json.Unmarshal([]byte(line), &raw))
+	assert.NotContains(t, raw, "level", "JSON output should not have slog 'level' field")
+	assert.NotContains(t, raw, "msg", "JSON output should not have slog 'msg' field")
+	assert.NotContains(t, raw, "component", "JSON output should not have slog 'component' field")
+
+	// Should have event fields
+	assert.Contains(t, raw, "type")
+	assert.Contains(t, raw, "timestamp")
+	assert.Contains(t, raw, "payload")
+	assert.Equal(t, "chainsync.transaction", raw["type"])
+}
+
+func TestFormatTextBlock(t *testing.T) {
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	l := New(WithFormat(FormatText))
+	require.NoError(t, l.Start())
+
+	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
+	testEvent := event.New(
+		"chainsync.block",
+		ts,
+		event.BlockContext{
+			Era:         "Conway",
+			BlockNumber: 9876543,
+			SlotNumber:  12345678,
+		},
+		event.BlockEvent{
+			BlockHash:        "abc12345def67890",
+			TransactionCount: 5,
+			BlockBodySize:    1234,
+		},
+	)
+
+	l.InputChan() <- testEvent
+	require.NoError(t, l.Stop())
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(output))
+	assert.Contains(t, line, "2026-01-15 14:30:45")
+	assert.Contains(t, line, "BLOCK")
+	assert.Contains(t, line, "slot=12345678")
+	assert.Contains(t, line, "block=9876543")
+	assert.Contains(t, line, "abc12345def67890")
+	assert.Contains(t, line, "era=Conway")
+	assert.Contains(t, line, "txs=5")
+	assert.Contains(t, line, "size=1234")
+}
+
+func TestFormatTextTransaction(t *testing.T) {
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	l := New(WithFormat(FormatText))
+	require.NoError(t, l.Start())
+
+	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
+	testEvent := event.New(
+		"chainsync.transaction",
+		ts,
+		event.TransactionContext{
+			TransactionHash: "deadbeef12345678",
+			BlockNumber:     100,
+			SlotNumber:      200,
+		},
+		event.TransactionEvent{
+			Fee: 180000,
+		},
+	)
+
+	l.InputChan() <- testEvent
+	require.NoError(t, l.Stop())
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(output))
+	assert.Contains(t, line, "TX")
+	assert.Contains(t, line, "tx=deadbeef12345678")
+	assert.Contains(t, line, "fee=180000")
+	assert.Contains(t, line, "inputs=0")
+	assert.Contains(t, line, "outputs=0")
+}
+
+func TestFormatTextRollback(t *testing.T) {
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	l := New(WithFormat(FormatText))
+	require.NoError(t, l.Start())
+
+	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
+	testEvent := event.New(
+		"chainsync.rollback",
+		ts,
+		nil,
+		event.RollbackEvent{
+			BlockHash:  "aabbccdd11223344",
+			SlotNumber: 999,
+		},
+	)
+
+	l.InputChan() <- testEvent
+	require.NoError(t, l.Stop())
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(output))
+	assert.Contains(t, line, "ROLLBACK")
+	assert.Contains(t, line, "slot=999")
+	assert.Contains(t, line, "aabbccdd11223344")
+}
+
+func TestFormatTextGovernance(t *testing.T) {
+	oldStdout := os.Stdout
+	defer func() { os.Stdout = oldStdout }()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+	os.Stdout = w
+
+	l := New(WithFormat(FormatText))
+	require.NoError(t, l.Start())
+
+	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
+	testEvent := event.New(
+		"chainsync.governance",
+		ts,
+		event.GovernanceContext{
+			TransactionHash: "govtx12345678abc",
+			BlockNumber:     500,
+			SlotNumber:      600,
+		},
+		event.GovernanceEvent{
+			ProposalProcedures: []event.ProposalProcedureData{
+				{ActionType: "Info"},
+			},
+			VotingProcedures: []event.VotingProcedureData{
+				{Vote: "Yes"},
+				{Vote: "No"},
+			},
+			DRepCertificates: []event.DRepCertificateData{
+				{CertificateType: "Registration"},
+			},
+		},
+	)
+
+	l.InputChan() <- testEvent
+	require.NoError(t, l.Stop())
+
+	w.Close()
+	output, err := io.ReadAll(r)
+	require.NoError(t, err)
+
+	line := strings.TrimSpace(string(output))
+	assert.Contains(t, line, "GOVERNANCE")
+	assert.Contains(t, line, "tx=govtx12345678abc")
+	assert.Contains(t, line, "proposals=1")
+	assert.Contains(t, line, "votes=2")
+	assert.Contains(t, line, "certs=1")
+}
+
+func TestFormatConstants(t *testing.T) {
+	assert.Equal(t, "text", FormatText)
+	assert.Equal(t, "json", FormatJSON)
+}
+
+func TestStopIdempotent(t *testing.T) {
+	l := New()
+	require.NoError(t, l.Start())
+	require.NoError(t, l.Stop())
+	// Second stop should not panic
+	require.NoError(t, l.Stop())
+}
+
+func TestOutputChanReturnsNil(t *testing.T) {
+	l := New()
+	assert.Nil(t, l.OutputChan())
+}

--- a/output/log/options.go
+++ b/output/log/options.go
@@ -25,9 +25,9 @@ func WithLogger(logger plugin.Logger) LogOptionFunc {
 	}
 }
 
-// WithLevel specifies the logging level
-func WithLevel(level string) LogOptionFunc {
+// WithFormat specifies the output format ("text" or "json")
+func WithFormat(format string) LogOptionFunc {
 	return func(o *LogOutput) {
-		o.level = level
+		o.format = format
 	}
 }

--- a/output/log/plugin.go
+++ b/output/log/plugin.go
@@ -20,7 +20,7 @@ import (
 )
 
 var cmdlineOptions struct {
-	level string
+	format string
 }
 
 func init() {
@@ -32,11 +32,11 @@ func init() {
 			NewFromOptionsFunc: NewFromCmdlineOptions,
 			Options: []plugin.PluginOption{
 				{
-					Name:         "level",
+					Name:         "format",
 					Type:         plugin.PluginOptionTypeString,
-					Description:  "specifies the log level to use",
-					DefaultValue: "info",
-					Dest:         &(cmdlineOptions.level),
+					Description:  "specifies the output format: text (human-readable, default) or json (machine-parseable)",
+					DefaultValue: "text",
+					Dest:         &(cmdlineOptions.format),
 				},
 			},
 		},
@@ -48,7 +48,7 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		WithLogger(
 			logging.GetLogger().With("plugin", "output.log"),
 		),
-		WithLevel(cmdlineOptions.level),
+		WithFormat(cmdlineOptions.format),
 	)
 	return p
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split logs by stream: application logs now go to stderr and event output goes to stdout. Added selectable text or JSON (NDJSON) formats for clean, pipe-friendly event logs.

- **New Features**
  - Added --output-log-format flag and log.format option: "text" (default) or "json".
  - Event data writes to stdout; application logs route to stderr (slog handlers updated).
  - Text prints one-line summaries; JSON emits one object per line with no slog envelope. Graceful shutdown prevents truncation. Tests and README updated.

- **Migration**
  - If you captured app logs from stdout, switch scripts to read stderr.
  - For machine parsing, use --output-log-format json and pipe stdout; redirect/suppress stderr as needed.

<sup>Written for commit aa1f682adfe6f3f66add80182092326a7656375b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable output format option with new `--output-log-format` flag, supporting text and JSON formats (defaults to text).

* **Bug Fixes**
  * JSON log output now correctly routes to stderr instead of stdout for proper stream separation.

* **Documentation**
  * Updated README with format selection examples and clarified stdout vs. stderr behavior for different log types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->