### PR TITLE
fix(chainsync): preserve event channels during auto-reconnect

### DIFF
--- a/input/chainsync/options.go
+++ b/input/chainsync/options.go
@@ -114,3 +114,12 @@ func WithDelayConfirmations(count uint) ChainSyncOptionFunc {
 		c.delayConfirmations = count
 	}
 }
+
+// WithReconnectCallback specifies a function to call after a successful
+// auto-reconnect. This allows consumers to detect reconnection events
+// and take action (e.g., logging, re-syncing state, resetting watchdogs).
+func WithReconnectCallback(callback func()) ChainSyncOptionFunc {
+	return func(c *ChainSync) {
+		c.reconnectCallback = callback
+	}
+}


### PR DESCRIPTION
Only create eventChan/errorChan when nil, preventing channel orphaning when Start() is called during auto-reconnect without a preceding Stop(). Add WithReconnectCallback option for consumer reconnection awareness.

Closes #610

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves event and error channels during auto-reconnect to prevent orphaned pipelines, and adds a reconnect callback hook for consumer visibility.

- **Bug Fixes**
  - Start() only creates eventChan/errorChan when nil, avoiding channel replacement during auto-reconnect.
  - Tests verify channel reuse on reconnect and new channel creation after Stop().

- **New Features**
  - WithReconnectCallback option to run a function after a successful auto-reconnect.

<sup>Written for commit dd5a8a15d368f92b19e1482e1e2499a9b4aea059. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

