### PR TITLE
feat: rename event types from chainsync.block/transaction to input.block/tr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,10 @@ Events are created with a simple schema.
 }
 ```
 
-The chainsync input produces three event types: `block`, `rollback`, and
-`transaction`. Each type has a unique payload.
+The chainsync input produces four event types: `input.block`, `input.rollback`,
+`input.transaction`, and `input.governance`. Each type has a unique payload.
 
-block:
+input.block:
 
 ```json
 {
@@ -43,7 +43,7 @@ block:
 }
 ```
 
-rollback:
+input.rollback:
 
 ```json
 {
@@ -54,7 +54,7 @@ rollback:
 }
 ```
 
-transaction:
+input.transaction:
 
 ```json
 {
@@ -99,6 +99,61 @@ transaction:
 }
 ```
 
+input.governance:
+
+```json
+{
+    "context": {
+        "transactionHash": "1234abcd1234abcd...",
+        "blockNumber": 123,
+        "slotNumber": 1234567,
+        "transactionIdx": 0,
+        "networkMagic": 1
+    },
+    "payload": {
+        "blockHash": "abcd123...",
+        "transactionCbor": "a500828258200a1ad...",
+        "proposalProcedures": [
+            {
+                "deposit": 1000000000,
+                "rewardAccount": "stake1u9abcd...",
+                "anchor": {
+                    "url": "https://example.com/proposal.json",
+                    "hash": "abcd1234..."
+                },
+                "action": {
+                    "parameterChange": {
+                        "govActionId": {
+                            "transactionId": "prev_tx_hash...",
+                            "govActionIdx": 0
+                        },
+                        "policyHash": "abcd1234..."
+                    }
+                }
+            }
+        ],
+        "votingProcedures": [
+            {
+                "voter": "drep1abcd...",
+                "voterType": "DRep",
+                "govActionId": {
+                    "transactionId": "action_tx_hash...",
+                    "govActionIdx": 0
+                },
+                "vote": "Yes",
+                "anchor": {
+                    "url": "https://example.com/vote-rationale.json",
+                    "hash": "efgh5678..."
+                }
+            }
+        ],
+        "drepCertificates": [...],
+        "voteDelegationCertificates": [...],
+        "committeeCertificates": [...]
+    }
+}
+```
+
 Each event is output individually. The log output supports two formats:
 
 - **text** (default) — human-readable, one line per event:
@@ -114,7 +169,7 @@ Each event is output individually. The log output supports two formats:
   piping to `jq` or other tooling):
 
   ```json
-  {"type":"chainsync.block","timestamp":"2026-02-07T09:18:40Z","context":{"blockNumber":9876543,"slotNumber":12345678},"payload":{"blockHash":"abc12345..."}}
+  {"type":"input.block","timestamp":"2026-02-07T09:18:40Z","context":{"blockNumber":9876543,"slotNumber":12345678},"payload":{"blockHash":"abc12345..."}}
   ```
 
 Select the format with `--output-log-format`:
@@ -281,16 +336,16 @@ docker run --rm -ti \
 
 #### Filtering on event type
 
-Only output `chainsync.transaction` event types
+Only output `input.transaction` event types
 
 ```bash
-adder -filter-type chainsync.transaction
+adder -filter-type input.transaction
 ```
 
-Only output `chainsync.rollback` and `chainsync.block` event types
+Only output `input.transaction` and `input.block` event types
 
 ```bash
-adder -filter-type chainsync.transaction,chainsync.block
+adder -filter-type input.transaction,input.block
 ```
 
 #### Filtering on asset policy
@@ -298,7 +353,7 @@ adder -filter-type chainsync.transaction,chainsync.block
 Only output transactions involving an asset with a particular policy ID
 
 ```bash
-adder -filter-type chainsync.transaction \
+adder -filter-type input.transaction \
   -filter-policy 13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f
 ```
 
@@ -307,7 +362,7 @@ adder -filter-type chainsync.transaction \
 Only output transactions involving a particular asset
 
 ```bash
-adder -filter-type chainsync.transaction \
+adder -filter-type input.transaction \
   -filter-asset asset108xu02ckwrfc8qs9d97mgyh4kn8gdu9w8f5sxk
 ```
 
@@ -317,7 +372,7 @@ Only output transactions involving both a particular policy ID and a particular
 asset (which do not need to be related)
 
 ```bash
-adder -filter-type chainsync.transaction \
+adder -filter-type input.transaction \
   -filter-asset asset108xu02ckwrfc8qs9d97mgyh4kn8gdu9w8f5sxk \
   -filter-policy 13aa2accf2e1561723aa26871e071fdf32c867cff7e7d50ad470d62f
 ```
@@ -327,7 +382,7 @@ adder -filter-type chainsync.transaction \
 Only output transactions with outputs matching a particular address
 
 ```bash
-adder -filter-type chainsync.transaction \
+adder -filter-type input.transaction \
   -filter-address addr1qyht4ja0zcn45qvyx477qlyp6j5ftu5ng0prt9608dxp6l2j2c79gy9l76sdg0xwhd7r0c0kna0tycz4y5s6mlenh8pq4jxtdy
 ```
 
@@ -336,7 +391,7 @@ adder -filter-type chainsync.transaction \
 Only output transactions with outputs matching a particular stake address
 
 ```bash
-adder -filter-type chainsync.transaction \
+adder -filter-type input.transaction \
   -filter-address stake1u9f9v0z5zzlldgx58n8tklphu8mf7h4jvp2j2gddluemnssjfnkzz
 ```
 
@@ -350,7 +405,7 @@ Push notifications will be sent to the FCM `project_id` specified in the
 details on how to send push notifications to mobile.
 
 ```bash
-adder -filter-type chainsync.block \
+adder -filter-type input.block \
   -output push \
   -output-push-serviceAccountFilePath /path/to/serviceAccount.json
 ```

--- a/event/governance.go
+++ b/event/governance.go
@@ -491,7 +491,7 @@ func extractGovernanceCertificates(tx ledger.Transaction) (
 			committee = append(committee, data)
 		}
 	}
-	return
+	return drep, voteDel, committee
 }
 
 // Helper functions

--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -396,7 +396,7 @@ func (c *ChainSync) handleRollBackward(
 ) error {
 	c.lastTip = tip
 	evt := event.New(
-		"chainsync.rollback",
+		"input.rollback",
 		time.Now(),
 		nil,
 		event.NewRollbackEvent(point),
@@ -467,7 +467,7 @@ func (c *ChainSync) handleRollForward(
 		return errors.New("unknown type")
 	}
 	blockEvt := event.New(
-		"chainsync.block",
+		"input.block",
 		time.Now(),
 		event.NewBlockHeaderContext(block.Header()),
 		event.NewBlockEvent(block, c.includeCbor),
@@ -487,7 +487,7 @@ func (c *ChainSync) handleRollForward(
 			return errors.New("invalid number of transactions")
 		}
 		txEvt := event.New(
-			"chainsync.transaction",
+			"input.transaction",
 			time.Now(),
 			event.NewTransactionContext(
 				block,
@@ -506,7 +506,7 @@ func (c *ChainSync) handleRollForward(
 		// Emit governance event if transaction contains governance data
 		if event.HasGovernanceData(transaction) {
 			govEvt := event.New(
-				"chainsync.governance",
+				"input.governance",
 				time.Now(),
 				event.NewGovernanceContext(
 					block,
@@ -574,7 +574,7 @@ func (c *ChainSync) handleBlockFetchBlock(
 	block ledger.Block,
 ) error {
 	blockEvt := event.New(
-		"chainsync.block",
+		"input.block",
 		time.Now(),
 		event.NewBlockContext(block, c.networkMagic),
 		event.NewBlockEvent(block, c.includeCbor),
@@ -594,7 +594,7 @@ func (c *ChainSync) handleBlockFetchBlock(
 			return errors.New("invalid number of transactions")
 		}
 		txEvt := event.New(
-			"chainsync.transaction",
+			"input.transaction",
 			time.Now(),
 			event.NewTransactionContext(
 				block,
@@ -613,7 +613,7 @@ func (c *ChainSync) handleBlockFetchBlock(
 		// Emit governance event if transaction contains governance data
 		if event.HasGovernanceData(transaction) {
 			govEvt := event.New(
-				"chainsync.governance",
+				"input.governance",
 				time.Now(),
 				event.NewGovernanceContext(
 					block,

--- a/input/chainsync/chainsync_test.go
+++ b/input/chainsync/chainsync_test.go
@@ -59,7 +59,7 @@ func TestHandleRollBackward(t *testing.T) {
 	select {
 	case evt := <-c.eventChan:
 		// Verify the event type
-		assert.Equal(t, "chainsync.rollback", evt.Type)
+		assert.Equal(t, "input.rollback", evt.Type)
 
 		// Verify the timestamp is not zero and is close to the current time
 		assert.False(t, evt.Timestamp.IsZero())

--- a/input/mempool/mempool.go
+++ b/input/mempool/mempool.go
@@ -316,7 +316,7 @@ func (m *Mempool) pollOnce() {
 		}
 		ctx := event.NewMempoolTransactionContext(p.tx, 0, m.networkMagic)
 		payload := event.NewTransactionEventFromTx(p.tx, m.includeCbor)
-		evt := event.New("mempool.transaction", time.Now(), ctx, payload)
+		evt := event.New("input.transaction", time.Now(), ctx, payload)
 		select {
 		case <-m.doneChan:
 			return

--- a/output/log/log_test.go
+++ b/output/log/log_test.go
@@ -51,7 +51,7 @@ func TestFormatJSONOutput(t *testing.T) {
 	require.NoError(t, l.Start())
 
 	testEvent := event.New(
-		"chainsync.block",
+		"input.block",
 		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		map[string]any{"blockNumber": 12345},
 		map[string]any{"hash": "abc123"},
@@ -73,7 +73,7 @@ func TestFormatJSONOutput(t *testing.T) {
 	err = json.Unmarshal([]byte(line), &parsed)
 	require.NoError(t, err, "output should be valid JSON: %s", line)
 
-	assert.Equal(t, "chainsync.block", parsed.Type)
+	assert.Equal(t, "input.block", parsed.Type)
 	assert.Equal(
 		t,
 		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -93,7 +93,7 @@ func TestFormatJSONNoSlogWrapper(t *testing.T) {
 	require.NoError(t, l.Start())
 
 	testEvent := event.New(
-		"chainsync.transaction",
+		"input.transaction",
 		time.Now(),
 		nil,
 		map[string]any{"fee": 200000},
@@ -119,7 +119,7 @@ func TestFormatJSONNoSlogWrapper(t *testing.T) {
 	assert.Contains(t, raw, "type")
 	assert.Contains(t, raw, "timestamp")
 	assert.Contains(t, raw, "payload")
-	assert.Equal(t, "chainsync.transaction", raw["type"])
+	assert.Equal(t, "input.transaction", raw["type"])
 }
 
 func TestFormatTextBlock(t *testing.T) {
@@ -134,7 +134,7 @@ func TestFormatTextBlock(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"chainsync.block",
+		"input.block",
 		ts,
 		event.BlockContext{
 			Era:         "Conway",
@@ -178,7 +178,7 @@ func TestFormatTextTransaction(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"chainsync.transaction",
+		"input.transaction",
 		ts,
 		event.TransactionContext{
 			TransactionHash: "deadbeef12345678",
@@ -217,7 +217,7 @@ func TestFormatTextRollback(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"chainsync.rollback",
+		"input.rollback",
 		ts,
 		nil,
 		event.RollbackEvent{
@@ -251,7 +251,7 @@ func TestFormatTextGovernance(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"chainsync.governance",
+		"input.governance",
 		ts,
 		event.GovernanceContext{
 			TransactionHash: "govtx12345678abc",

--- a/output/notify/notify.go
+++ b/output/notify/notify.go
@@ -77,7 +77,7 @@ func (n *NotifyOutput) Start() error {
 				return
 			}
 			switch evt.Type {
-			case "chainsync.block":
+			case "input.block":
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("block event has nil payload")
@@ -106,7 +106,7 @@ func (n *NotifyOutput) Start() error {
 					slog.Error("failed to send block notification", "error", err)
 					continue
 				}
-			case "chainsync.rollback":
+			case "input.rollback":
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("rollback event has nil payload")
@@ -126,7 +126,7 @@ func (n *NotifyOutput) Start() error {
 					slog.Error("failed to send rollback notification", "error", err)
 					continue
 				}
-			case "chainsync.transaction":
+			case "input.transaction":
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("transaction event has nil payload")

--- a/output/push/push.go
+++ b/output/push/push.go
@@ -84,7 +84,7 @@ func (p *PushOutput) Start() error {
 			}
 
 			switch evt.Type {
-			case "chainsync.block":
+			case "input.block":
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("block event has nil payload")
@@ -118,7 +118,7 @@ func (p *PushOutput) Start() error {
 				// Send notification
 				p.processFcmNotifications(title, body)
 
-			case "chainsync.rollback":
+			case "input.rollback":
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("rollback event has nil payload")
@@ -133,7 +133,7 @@ func (p *PushOutput) Start() error {
 						re.BlockHash,
 					),
 				)
-			case "chainsync.transaction":
+			case "input.transaction":
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("transaction event has nil payload")

--- a/output/telegram/telegram_test.go
+++ b/output/telegram/telegram_test.go
@@ -292,7 +292,7 @@ func TestProcessEventInvalidPayloadNoPanic(t *testing.T) {
 
 	// Wrong payload type for block — should log and return, not panic
 	evt := &event.Event{
-		Type:    "chainsync.block",
+		Type:    "input.block",
 		Payload: "not a BlockEvent",
 		Context: event.BlockContext{
 			Era: "Conway", BlockNumber: 1, SlotNumber: 1, NetworkMagic: mainnetNetworkMagic,
@@ -301,7 +301,7 @@ func TestProcessEventInvalidPayloadNoPanic(t *testing.T) {
 	tg.processEvent(evt)
 
 	// Wrong payload type for rollback
-	evt2 := &event.Event{Type: "chainsync.rollback", Payload: 12345}
+	evt2 := &event.Event{Type: "input.rollback", Payload: 12345}
 	tg.processEvent(evt2)
 
 	// Unknown event type


### PR DESCRIPTION
…ansaction

Closes #606 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed all event types to input.* across chain-sync and mempool for simpler filtering and consistent plugin names. Updated docs, tests, and outputs; Telegram and webhook now format input.governance; rollbacks emit input.rollback.

- **Migration**
  - Replace chainsync.block/transaction/governance and mempool.transaction with input.block/transaction/governance; replace chainsync.rollback with input.rollback.
  - Use -filter-type input.* in CLI; event.type is now input.block, input.transaction, input.governance, input.rollback.
  - Payloads and contexts are unchanged.

- **Bug Fixes**
  - Fixed governance certificate extraction to return drep, voteDelegation, and committee in the correct order.

<sup>Written for commit d14c0fac41fd0691ab0ce88352bc102f35af67cb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README examples and filtering guidance updated to use input.* event naming consistently.

* **Updates**
  * Event type identifiers renamed to the input.* namespace across event emission, handling, notifications, webhooks, push/telegram delivery, and mempool output (e.g., input.block, input.transaction, input.rollback, input.governance).

* **Tests**
  * Test expectations and examples updated to reflect input.* event naming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->