### PR TITLE
feat(tray): adder config

### DIFF
--- a/input/mempool/mempool.go
+++ b/input/mempool/mempool.go
@@ -396,6 +396,7 @@ func (m *Mempool) getKupoClient() (*kugo.Client, error) {
 		return nil, fmt.Errorf("failed to create health check request: %w", err)
 	}
 	httpClient := &http.Client{Timeout: kupoHealthTimeout}
+	// #nosec G704 -- Kupo endpoint is user-configured and validated before use.
 	resp, err := httpClient.Do(req)
 	if err != nil {
 		switch {

--- a/output/webhook/webhook.go
+++ b/output/webhook/webhook.go
@@ -332,6 +332,7 @@ func (w *WebhookOutput) SendWebhook(e *event.Event) error {
 	}
 	client := &http.Client{Transport: customTransport}
 	// Send payload
+	// #nosec G704 -- Webhook URL is user-configured and intentionally allowed.
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("%w", err)

--- a/tray/adder_config.go
+++ b/tray/adder_config.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tray
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// MonitorTemplate represents a pre-configured monitoring template.
+type MonitorTemplate int
+
+const (
+	WatchWallet MonitorTemplate = iota
+	TrackDRep
+	MonitorPool
+)
+
+// String returns the display name of the template.
+func (t MonitorTemplate) String() string {
+	switch t {
+	case WatchWallet:
+		return "Watch Wallet"
+	case TrackDRep:
+		return "Track DRep"
+	case MonitorPool:
+		return "Monitor Pool"
+	default:
+		return "Unknown"
+	}
+}
+
+// AdderConfigParams holds the parameters for generating an adder
+// configuration.
+type AdderConfigParams struct {
+	Network  string
+	Template MonitorTemplate
+	Param    string // The address/drep/pool value depending on Template
+	Output   string // Output plugin name (default: "log")
+	Format   string // Output format (default: "json")
+}
+
+// adderConfig is the internal structure matching adder's config.yaml
+// format. We use map types for the plugins section to match adder's
+// flexible config.
+type adderConfig struct {
+	Input   string                            `yaml:"input"`
+	Output  string                            `yaml:"output"`
+	API     adderAPIConfig                    `yaml:"api"`
+	Logging adderLoggingConfig                `yaml:"logging"`
+	Plugins map[string]map[string]interface{} `yaml:"plugins"`
+}
+
+type adderAPIConfig struct {
+	Address string `yaml:"address"`
+	Port    uint   `yaml:"port"`
+}
+
+type adderLoggingConfig struct {
+	Level string `yaml:"level"`
+}
+
+// GenerateAdderConfig builds an adder configuration from the given
+// parameters. The API server is always enabled because adder-tray
+// connects to its /events endpoint for desktop notifications and
+// /healthcheck for status monitoring.
+func GenerateAdderConfig(params AdderConfigParams) ([]byte, error) {
+	if params.Network == "" {
+		return nil, errors.New("network is required")
+	}
+	if params.Param == "" {
+		return nil, errors.New("filter parameter is required")
+	}
+
+	output := params.Output
+	if output == "" {
+		output = "log"
+	}
+	format := params.Format
+	if format == "" {
+		format = "json"
+	}
+
+	cfg := adderConfig{
+		Input:  "chainsync",
+		Output: output,
+		API: adderAPIConfig{
+			Address: "127.0.0.1",
+			Port:    8080,
+		},
+		Logging: adderLoggingConfig{
+			Level: "info",
+		},
+		Plugins: map[string]map[string]interface{}{
+			"input": {
+				"chainsync": map[string]interface{}{
+					"network": params.Network,
+				},
+			},
+			"output": {
+				output: map[string]interface{}{
+					"format": format,
+				},
+			},
+		},
+	}
+
+	// Add filter config based on template
+	filterKey := templateFilterKey(params.Template)
+	if filterKey == "" {
+		return nil, fmt.Errorf("unsupported monitor template: %d", params.Template)
+	}
+	cfg.Plugins["filter"] = map[string]interface{}{
+		"chainsync": map[string]interface{}{
+			filterKey: params.Param,
+		},
+	}
+
+	return yaml.Marshal(&cfg)
+}
+
+// templateFilterKey returns the filter configuration key for a
+// template. Returns an empty string for unrecognized templates.
+func templateFilterKey(t MonitorTemplate) string {
+	switch t {
+	case WatchWallet:
+		return "address"
+	case TrackDRep:
+		return "drep"
+	case MonitorPool:
+		return "pool"
+	default:
+		return ""
+	}
+}
+
+// AdderConfigPath returns the path to the adder config file in the
+// config directory.
+func AdderConfigPath() string {
+	return filepath.Join(ConfigDir(), "config.yaml")
+}
+
+// WriteAdderConfig writes the adder configuration to the config
+// directory.
+func WriteAdderConfig(params AdderConfigParams) error {
+	data, err := GenerateAdderConfig(params)
+	if err != nil {
+		return fmt.Errorf("generating config: %w", err)
+	}
+
+	dir := ConfigDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return fmt.Errorf("creating config directory: %w", err)
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return fmt.Errorf("setting config directory permissions: %w", err)
+	}
+
+	if err := os.WriteFile(AdderConfigPath(), data, 0o600); err != nil {
+		return fmt.Errorf("writing config file: %w", err)
+	}
+
+	return nil
+}

--- a/tray/adder_config_test.go
+++ b/tray/adder_config_test.go
@@ -1,0 +1,245 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tray
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+func TestMonitorTemplateString(t *testing.T) {
+	tests := []struct {
+		tmpl MonitorTemplate
+		want string
+	}{
+		{WatchWallet, "Watch Wallet"},
+		{TrackDRep, "Track DRep"},
+		{MonitorPool, "Monitor Pool"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, tt.tmpl.String())
+	}
+}
+
+func TestGenerateAdderConfig_WatchWallet(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: WatchWallet,
+		Param:    "addr1qtest123",
+	}
+	data, err := GenerateAdderConfig(params)
+	require.NoError(t, err)
+
+	// Unmarshal back and verify structure
+	var cfg map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+	assert.Equal(t, "chainsync", cfg["input"])
+	assert.Equal(t, "log", cfg["output"])
+
+	// Verify API config
+	api, ok := cfg["api"].(map[string]interface{})
+	require.True(t, ok, "api should be a map")
+	assert.Equal(t, "127.0.0.1", api["address"])
+	assert.Equal(t, 8080, api["port"])
+
+	// Verify plugins structure
+	plugins, ok := cfg["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins should be a map")
+	input, ok := plugins["input"].(map[string]interface{})
+	require.True(t, ok, "plugins.input should be a map")
+	chainsync, ok := input["chainsync"].(map[string]interface{})
+	require.True(t, ok, "plugins.input.chainsync should be a map")
+	assert.Equal(t, "mainnet", chainsync["network"])
+
+	// Verify filter
+	filter, ok := plugins["filter"].(map[string]interface{})
+	require.True(t, ok, "plugins.filter should be a map")
+	filterChainsync, ok := filter["chainsync"].(map[string]interface{})
+	require.True(t, ok, "plugins.filter.chainsync should be a map")
+	assert.Equal(t, "addr1qtest123", filterChainsync["address"])
+}
+
+func TestGenerateAdderConfig_TrackDRep(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "preview",
+		Template: TrackDRep,
+		Param:    "drep1test456",
+	}
+	data, err := GenerateAdderConfig(params)
+	require.NoError(t, err)
+
+	var cfg map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+	plugins, ok := cfg["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins should be a map")
+	filter, ok := plugins["filter"].(map[string]interface{})
+	require.True(t, ok, "plugins.filter should be a map")
+	filterChainsync, ok := filter["chainsync"].(map[string]interface{})
+	require.True(t, ok, "plugins.filter.chainsync should be a map")
+	assert.Equal(t, "drep1test456", filterChainsync["drep"])
+}
+
+func TestGenerateAdderConfig_MonitorPool(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: MonitorPool,
+		Param:    "pool1test789",
+	}
+	data, err := GenerateAdderConfig(params)
+	require.NoError(t, err)
+
+	var cfg map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+	plugins, ok := cfg["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins should be a map")
+	filter, ok := plugins["filter"].(map[string]interface{})
+	require.True(t, ok, "plugins.filter should be a map")
+	filterChainsync, ok := filter["chainsync"].(map[string]interface{})
+	require.True(t, ok, "plugins.filter.chainsync should be a map")
+	assert.Equal(t, "pool1test789", filterChainsync["pool"])
+}
+
+func TestGenerateAdderConfig_CustomOutput(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: WatchWallet,
+		Param:    "addr1qtest",
+		Output:   "webhook",
+		Format:   "jsonl",
+	}
+	data, err := GenerateAdderConfig(params)
+	require.NoError(t, err)
+
+	var cfg map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+
+	assert.Equal(t, "webhook", cfg["output"])
+	plugins, ok := cfg["plugins"].(map[string]interface{})
+	require.True(t, ok, "plugins should be a map")
+	output, ok := plugins["output"].(map[string]interface{})
+	require.True(t, ok, "plugins.output should be a map")
+	webhook, ok := output["webhook"].(map[string]interface{})
+	require.True(t, ok, "plugins.output.webhook should be a map")
+	assert.Equal(t, "jsonl", webhook["format"])
+}
+
+func TestGenerateAdderConfig_NetworkRequired(t *testing.T) {
+	params := AdderConfigParams{
+		Template: WatchWallet,
+		Param:    "addr1qtest",
+	}
+	_, err := GenerateAdderConfig(params)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "network")
+}
+
+func TestGenerateAdderConfig_ParamRequired(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: WatchWallet,
+	}
+	_, err := GenerateAdderConfig(params)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "parameter")
+}
+
+func TestGenerateAdderConfig_RoundTrip(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: WatchWallet,
+		Param:    "addr1qtest",
+	}
+	data, err := GenerateAdderConfig(params)
+	require.NoError(t, err)
+
+	// Should be valid YAML that can be unmarshaled and re-marshaled
+	var intermediate interface{}
+	require.NoError(t, yaml.Unmarshal(data, &intermediate))
+	data2, err := yaml.Marshal(intermediate)
+	require.NoError(t, err)
+	assert.NotEmpty(t, data2)
+}
+
+func TestAdderConfigPath(t *testing.T) {
+	path := AdderConfigPath()
+	assert.True(t, filepath.IsAbs(path))
+	assert.Equal(t, "config.yaml", filepath.Base(path))
+}
+
+func TestWriteAdderConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	switch runtime.GOOS {
+	case "linux":
+		t.Setenv("XDG_CONFIG_HOME", tmpDir)
+	case "darwin":
+		t.Setenv("HOME", tmpDir)
+	case "windows":
+		t.Setenv("APPDATA", tmpDir)
+	default:
+		t.Skipf("unsupported platform: %s", runtime.GOOS)
+	}
+
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: WatchWallet,
+		Param:    "addr1qtest",
+	}
+
+	err := WriteAdderConfig(params)
+	require.NoError(t, err)
+
+	// Verify file exists
+	path := AdderConfigPath()
+	info, err := os.Stat(path)
+	require.NoError(t, err)
+	if runtime.GOOS != "windows" {
+		assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	}
+
+	// Verify content is valid YAML
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	var cfg map[string]interface{}
+	require.NoError(t, yaml.Unmarshal(data, &cfg))
+	assert.Equal(t, "chainsync", cfg["input"])
+}
+
+func TestTemplateFilterKey(t *testing.T) {
+	assert.Equal(t, "address", templateFilterKey(WatchWallet))
+	assert.Equal(t, "drep", templateFilterKey(TrackDRep))
+	assert.Equal(t, "pool", templateFilterKey(MonitorPool))
+	assert.Equal(t, "", templateFilterKey(MonitorTemplate(99)))
+}
+
+func TestGenerateAdderConfig_UnsupportedTemplate(t *testing.T) {
+	params := AdderConfigParams{
+		Network:  "mainnet",
+		Template: MonitorTemplate(99),
+		Param:    "test",
+	}
+	_, err := GenerateAdderConfig(params)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported monitor template")
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an adder config generator to the tray with wallet/DRep/pool templates; writes a secure config.yaml with sensible defaults and enables the adder API at 127.0.0.1:8080. Hardens Kupo, FCM, and webhook HTTP handling to prevent malformed requests.

- **New Features**
  - Generate adder YAML with defaults (output=log, format=json) and enable the API at 127.0.0.1:8080.
  - Map wallet/DRep/pool templates to filter keys under plugins.filter.chainsync and set the chainsync network.
  - Add AdderConfigPath/WriteAdderConfig; create config dir (0700) and write config.yaml (0600); tests for validation, round‑trip, path, and permissions.

- **Bug Fixes**
  - Validate Kupo URL scheme and host; build the /health URL with url.URL before client use.
  - Build the FCM URL with url.URL and remove payload debug print; annotate HTTP calls with G704 #nosec where endpoints are fixed or validated (Kupo, FCM, webhook, mempool).

<sup>Written for commit 65caba39ca6cab0cb3a5a095eb775683355a06da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configuration generator for monitoring with selectable templates (wallet, DRep, pool), YAML output, and secure on-disk persistence with proper permissions.

* **Tests**
  * Comprehensive coverage for config generation, template mappings, validation, YAML round-trip, path resolution, and platform file-permission behavior.

* **Improvements**
  * Stricter URL validation and more robust HTTP request construction for health-checks, push and webhook integrations; removed stray debug output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->