### PR TITLE
feat(event): implement custom JSON marshaling for TransactionEvent

### DIFF
--- a/event/tx.go
+++ b/event/tx.go
@@ -80,34 +80,23 @@ func (t TransactionEvent) MarshalJSON() ([]byte, error) {
 			}
 			witnesses.Redeemers[fmt.Sprintf("%s:%d", redeemerTagString(k.Tag), k.Index)] = v
 		}
+		// Suppress empty witness objects from the JSON output.
+		if len(witnesses.Vkey) == 0 && len(witnesses.NativeScripts) == 0 &&
+			len(witnesses.Bootstrap) == 0 && len(witnesses.PlutusData) == 0 &&
+			len(witnesses.PlutusV1Scripts) == 0 && len(witnesses.PlutusV2Scripts) == 0 &&
+			len(witnesses.PlutusV3Scripts) == 0 && len(witnesses.Redeemers) == 0 {
+			witnesses = nil
+		}
 	}
 
+	// Alias breaks the MarshalJSON method set to prevent infinite recursion.
+	type Alias TransactionEvent
 	return json.Marshal(struct {
-		Witnesses       *witnessesJSON               `json:"witnesses,omitempty"`
-		Withdrawals     map[string]uint64             `json:"withdrawals,omitempty"`
-		Metadata        lcommon.TransactionMetadatum  `json:"metadata,omitempty"`
-		BlockHash       string                        `json:"blockHash"`
-		ReferenceInputs []ledger.TransactionInput     `json:"referenceInputs,omitempty"`
-		Certificates    []ledger.Certificate          `json:"certificates,omitempty"`
-		Outputs         []ledger.TransactionOutput    `json:"outputs"`
-		ResolvedInputs  []ledger.TransactionOutput    `json:"resolvedInputs,omitempty"`
-		Inputs          []ledger.TransactionInput     `json:"inputs"`
-		TransactionCbor byteSliceJsonHex              `json:"transactionCbor,omitempty"`
-		Fee             uint64                        `json:"fee"`
-		TTL             uint64                        `json:"ttl,omitempty"`
+		*Alias
+		Witnesses *witnessesJSON `json:"witnesses,omitempty"`
 	}{
-		Witnesses:       witnesses,
-		Withdrawals:     t.Withdrawals,
-		Metadata:        t.Metadata,
-		BlockHash:       t.BlockHash,
-		ReferenceInputs: t.ReferenceInputs,
-		Certificates:    t.Certificates,
-		Outputs:         t.Outputs,
-		ResolvedInputs:  t.ResolvedInputs,
-		Inputs:          t.Inputs,
-		TransactionCbor: t.TransactionCbor,
-		Fee:             t.Fee,
-		TTL:             t.TTL,
+		Alias:     (*Alias)(&t),
+		Witnesses: witnesses,
 	})
 }
 


### PR DESCRIPTION
- Added MarshalJSON method to TransactionEvent to handle Witnesses field serialization.
- Updated Witnesses field to be omitted from default JSON output.
- Introduced redeemerTagString function for converting redeemer tags to string format.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add custom JSON marshaling for TransactionEvent to safely serialize Witnesses and their redeemers using string keys. Prevents JSON encoding errors, preserves the event shape, and reduces payload size by suppressing empty witness objects.

- **New Features**
  - Custom MarshalJSON builds a witnesses object; redeemers keyed as "tag:index" (e.g., "spend:0").
  - Witnesses are omitted from default JSON and included only via the custom marshaler; empty witnesses are suppressed.
  - Added redeemerTagString; uses an alias type to avoid recursion during marshaling.

<sup>Written for commit 92921155083feeb5c6d40f92e81268b15cc581ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated transaction event JSON output: raw witness data is now hidden by default and replaced with a structured, more readable representation of witnesses and redeemers.
  * Redeemer keys are rendered as human-friendly "tag:index" strings.
  * Empty witness sections are omitted to reduce noise in serialized output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->