### PR TITLE
feat(tray): add StartService and StopService helpers and update tray …

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,12 @@ Each event is output individually. The log output supports two formats:
   piping to `jq` or other tooling):
 
   ```json
-  {"type":"input.block","timestamp":"2026-02-07T09:18:40Z","context":{"blockNumber":9876543,"slotNumber":12345678},"payload":{"blockHash":"abc12345..."}}
+  {
+    "type": "input.block",
+    "timestamp": "2026-02-07T09:18:40Z",
+    "context": { "blockNumber": 9876543, "slotNumber": 12345678 },
+    "payload": { "blockHash": "abc12345..." }
+  }
   ```
 
 Select the format with `--output-log-format`:

--- a/api/events.go
+++ b/api/events.go
@@ -56,7 +56,7 @@ func NewEventHub(ringSize uint) *EventHub {
 	if ringSize == 0 {
 		ringSize = defaultRingSize
 	}
-	size := int(ringSize)
+	size := int(ringSize) //nolint:gosec // uint size constraint enforced by API config
 	return &EventHub{
 		clients:  make(map[*eventClient]struct{}),
 		ring:     make([]event.Event, size),
@@ -145,7 +145,7 @@ func (h *EventHub) InputChan() chan<- event.Event {
 func (h *EventHub) recentEventsLocked(
 	typeFilter map[string]bool,
 ) []event.Event {
-	var events []event.Event
+	events := make([]event.Event, 0, len(h.ring))
 	start := 0
 	count := h.ringPos
 	if h.ringFull {

--- a/output/telegram/telegram.go
+++ b/output/telegram/telegram.go
@@ -499,7 +499,7 @@ func truncateMessage(text string, maxLen int) string {
 	if keepUnits <= 0 {
 		return suffix
 	}
-	var runes []rune
+	runes := make([]rune, 0, len(text))
 	units := 0
 	for _, r := range text {
 		need := 1

--- a/tray/app.go
+++ b/tray/app.go
@@ -15,9 +15,12 @@
 package tray
 
 import (
+	"image/color"
 	"log/slog"
 	"os/exec"
 	"runtime"
+	"strconv"
+	"time"
 
 	"fyne.io/systray"
 )
@@ -69,13 +72,9 @@ func (a *App) onReady() {
 	mStatus.Disable()
 	systray.AddSeparator()
 
-	mConnect := systray.AddMenuItem("Connect", "Connect to adder")
-	mDisconnect := systray.AddMenuItem(
-		"Disconnect", "Disconnect from adder",
-	)
-	mReconnect := systray.AddMenuItem(
-		"Reconnect", "Reconnect to adder",
-	)
+	mStart := systray.AddMenuItem("Start", "Start adder service")
+	mStop := systray.AddMenuItem("Stop", "Stop adder service")
+	mRestart := systray.AddMenuItem("Restart", "Restart adder service")
 	systray.AddSeparator()
 
 	mShowConfig := systray.AddMenuItem(
@@ -86,32 +85,79 @@ func (a *App) onReady() {
 	)
 	systray.AddSeparator()
 
+	mAbout := systray.AddMenuItem("About", "About Adder")
 	mQuit := systray.AddMenuItem("Quit", "Quit adder-tray")
 
 	// Update status menu item when connection status changes
 	a.conn.status.OnChange(func(s Status) {
 		mStatus.SetTitle("Status: " + s.String())
+
+		// Update icon color based on status
+		switch s {
+		case StatusConnected:
+			systray.SetIcon(generateIcon(color.RGBA{0, 255, 0, 255})) // Green
+		case StatusReconnecting, StatusStarting:
+			systray.SetIcon(generateIcon(color.RGBA{255, 255, 0, 255})) // Yellow
+		case StatusStopped, StatusError:
+			systray.SetIcon(generateIcon(color.RGBA{255, 0, 0, 255})) // Red
+		default:
+			systray.SetIcon(generateIcon(color.RGBA{128, 128, 128, 255})) // Gray
+		}
 	})
+
+	// Initial icon state
+	systray.SetIcon(generateIcon(color.RGBA{128, 128, 128, 255}))
+
+	// Event tracking for tooltip
+	go func() {
+		var eventCount int
+		var lastEvent time.Time
+		for range a.conn.Events() {
+			eventCount++
+			lastEvent = time.Now()
+
+			tooltip := "Adder - Cardano Event Streamer"
+			if eventCount > 0 {
+				tooltip += "\nEvents: " + strconv.Itoa(eventCount) + "\nLast: " + lastEvent.Format("15:04:05")
+			}
+			systray.SetTooltip(tooltip)
+		}
+	}()
 
 	go func() {
 		for {
 			select {
-			case <-mConnect.ClickedCh:
+			case <-mStart.ClickedCh:
+				if err := StartService(); err != nil {
+					slog.Error("failed to start service", "error", err)
+				}
 				if err := a.conn.Connect(); err != nil {
 					slog.Error(
 						"failed to connect",
 						"error", err,
 					)
 				}
-			case <-mDisconnect.ClickedCh:
+			case <-mStop.ClickedCh:
 				a.conn.Disconnect()
-			case <-mReconnect.ClickedCh:
-				if err := a.conn.Reconnect(); err != nil {
+				if err := StopService(); err != nil {
+					slog.Error("failed to stop service", "error", err)
+				}
+			case <-mRestart.ClickedCh:
+				a.conn.Disconnect()
+				if err := StopService(); err != nil {
+					slog.Error("failed to stop service", "error", err)
+				}
+				if err := StartService(); err != nil {
+					slog.Error("failed to start service", "error", err)
+				}
+				if err := a.conn.Connect(); err != nil {
 					slog.Error(
-						"failed to reconnect",
+						"failed to connect",
 						"error", err,
 					)
 				}
+			case <-mAbout.ClickedCh:
+				openURL("https://github.com/blinklabs-io/adder")
 			case <-mShowConfig.ClickedCh:
 				openFolder(ConfigDir())
 			case <-mShowLogs.ClickedCh:
@@ -161,6 +207,29 @@ func openFolder(dir string) {
 	p := exec.Command(cmd, dir) //nolint:gosec // directory path from internal config
 	if err := p.Start(); err != nil {
 		slog.Error("failed to open folder", "dir", dir, "error", err)
+		return
+	}
+	_ = p.Process.Release()
+}
+
+// openURL opens the given URL in the default browser.
+func openURL(url string) {
+	var cmd string
+	var args []string
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = "open"
+		args = []string{url}
+	case "windows":
+		cmd = "cmd"
+		args = []string{"/c", "start", "", url}
+	default:
+		cmd = "xdg-open"
+		args = []string{url}
+	}
+	p := exec.Command(cmd, args...) //nolint:gosec // hardcoded URL
+	if err := p.Start(); err != nil {
+		slog.Error("failed to open URL", "url", url, "error", err)
 		return
 	}
 	_ = p.Process.Release()

--- a/tray/icon_gen.go
+++ b/tray/icon_gen.go
@@ -1,0 +1,29 @@
+package tray
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+)
+
+// generateIcon creates a simple 16x16 circle icon in the given color.
+func generateIcon(c color.Color) []byte {
+	const size = 16
+	img := image.NewRGBA(image.Rect(0, 0, size, size))
+	radius := size / 2
+
+	for y := 0; y < size; y++ {
+		for x := 0; x < size; x++ {
+			dx := x - radius
+			dy := y - radius
+			if dx*dx+dy*dy <= radius*radius {
+				img.Set(x, y, c)
+			}
+		}
+	}
+
+	var buf bytes.Buffer
+	_ = png.Encode(&buf, img)
+	return buf.Bytes()
+}

--- a/tray/service.go
+++ b/tray/service.go
@@ -81,3 +81,15 @@ func UnregisterService() error {
 func ServiceStatusCheck() (ServiceStatus, error) {
 	return serviceStatusCheck()
 }
+
+// StartService starts the adder system service using the
+// platform-specific mechanism.
+func StartService() error {
+	return startService()
+}
+
+// StopService stops the adder system service using the
+// platform-specific mechanism.
+func StopService() error {
+	return stopService()
+}

--- a/tray/service_darwin.go
+++ b/tray/service_darwin.go
@@ -27,8 +27,10 @@ import (
 	"text/template"
 )
 
-const launchAgentLabel = "io.blinklabs.adder"
-const launchAgentFile = "io.blinklabs.adder.plist"
+const (
+	launchAgentLabel = "io.blinklabs.adder"
+	launchAgentFile  = "io.blinklabs.adder.plist"
+)
 
 const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -110,24 +112,30 @@ func registerService(cfg ServiceConfig) error {
 		return err
 	}
 
-	if err := os.WriteFile(servicePlistPath(), data, 0o644); err != nil {
+	if err := os.WriteFile(servicePlistPath(), data, 0o644); err != nil { //nolint:gosec // plist files need 0644 permissions
 		return fmt.Errorf("writing plist file: %w", err)
 	}
 
-	if out, err := exec.Command(
-		"launchctl", "load", "-w", servicePlistPath(),
+	target := fmt.Sprintf("gui/%d", os.Getuid())
+	if out, err := exec.Command( //nolint:gosec // paths are generated internally
+		"launchctl", "bootstrap", target, servicePlistPath(),
 	).CombinedOutput(); err != nil {
-		return fmt.Errorf("loading launch agent: %s: %w", strings.TrimSpace(string(out)), err)
+		if !strings.Contains(string(out), "service already bootstrapped") {
+			return fmt.Errorf("loading launch agent: %s: %w", strings.TrimSpace(string(out)), err)
+		}
 	}
 
 	return nil
 }
 
 func unregisterService() error {
-	if out, err := exec.Command(
-		"launchctl", "unload", servicePlistPath(),
+	target := fmt.Sprintf("gui/%d/%s", os.Getuid(), launchAgentLabel)
+	if out, err := exec.Command( //nolint:gosec // paths are generated internally
+		"launchctl", "bootout", target,
 	).CombinedOutput(); err != nil {
-		return fmt.Errorf("unloading launch agent: %s: %w", strings.TrimSpace(string(out)), err)
+		if !strings.Contains(string(out), "Could not find service") {
+			return fmt.Errorf("unloading launch agent: %s: %w", strings.TrimSpace(string(out)), err)
+		}
 	}
 
 	if err := os.Remove(servicePlistPath()); err != nil && !os.IsNotExist(err) {
@@ -147,4 +155,28 @@ func serviceStatusCheck() (ServiceStatus, error) {
 	}
 
 	return ServiceRegistered, nil
+}
+
+func startService() error {
+	target := fmt.Sprintf("gui/%d", os.Getuid())
+	if out, err := exec.Command( //nolint:gosec // paths are generated internally
+		"launchctl", "bootstrap", target, servicePlistPath(),
+	).CombinedOutput(); err != nil {
+		if !strings.Contains(string(out), "service already bootstrapped") {
+			return fmt.Errorf("starting launch agent: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+	}
+	return nil
+}
+
+func stopService() error {
+	target := fmt.Sprintf("gui/%d/%s", os.Getuid(), launchAgentLabel)
+	if out, err := exec.Command( //nolint:gosec // paths are generated internally
+		"launchctl", "bootout", target,
+	).CombinedOutput(); err != nil {
+		if !strings.Contains(string(out), "Could not find service") {
+			return fmt.Errorf("stopping launch agent: %s: %w", strings.TrimSpace(string(out)), err)
+		}
+	}
+	return nil
 }

--- a/tray/service_linux.go
+++ b/tray/service_linux.go
@@ -126,3 +126,17 @@ func serviceStatusCheck() (ServiceStatus, error) {
 
 	return ServiceRegistered, nil
 }
+
+func startService() error {
+	if out, err := exec.Command("systemctl", "--user", "start", serviceName).CombinedOutput(); err != nil {
+		return fmt.Errorf("starting service: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func stopService() error {
+	if out, err := exec.Command("systemctl", "--user", "stop", serviceName).CombinedOutput(); err != nil {
+		return fmt.Errorf("stopping service: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}

--- a/tray/service_windows.go
+++ b/tray/service_windows.go
@@ -90,3 +90,23 @@ func serviceStatusCheck() (ServiceStatus, error) {
 
 	return ServiceRegistered, nil
 }
+
+func startService() error {
+	out, err := exec.Command(
+		"schtasks.exe", "/Run", "/TN", taskName,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("starting scheduled task: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}
+
+func stopService() error {
+	out, err := exec.Command(
+		"schtasks.exe", "/End", "/TN", taskName,
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("stopping scheduled task: %s: %w", strings.TrimSpace(string(out)), err)
+	}
+	return nil
+}


### PR DESCRIPTION
…menu

Closes #677

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `StartService`/`StopService` helpers and update the tray to control the adder service with Start/Stop/Restart, a status-aware icon, and a live tooltip. Implements service control on macOS, Linux, and Windows. Closes #677.

- New Features
  - Tray menu replaces Connect/Disconnect/Reconnect with Start/Stop/Restart wired to `StartService`/`StopService` and connection handling.
  - Platform control: `launchctl` (macOS), `systemctl --user` (Linux), `schtasks.exe` (Windows); macOS now uses `launchctl bootstrap/bootout`.
  - Status icon generated at runtime with colors: green (connected), yellow (starting/reconnecting), red (stopped/error), gray (idle).
  - Tooltip shows total events and last event time; adds About link to project page.

- Refactors
  - Small allocation tweaks in events hub and Telegram; prettified JSON example in README.

<sup>Written for commit 2fcc7d7260226f3f34f8a3ed2e9adfdc46404e9a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tray menu now includes Start, Stop, and Restart service controls
  * Tray icon color updates dynamically to reflect connection status
  * Tooltip text updates continuously based on connection events
  * Added About menu item to the tray interface
  * Service control now works consistently across macOS, Linux, and Windows

* **Documentation**
  * Reformatted example output in README for improved readability

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/blinklabs-io/adder/pull/719)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->