### PR TITLE
test(tray): add missing test TestBackoffDelay

### DIFF
--- a/tray/events_test.go
+++ b/tray/events_test.go
@@ -307,3 +307,28 @@ func waitForStatus(
 		expected, timeout, tracker.Status(),
 	)
 }
+
+func TestBackoffDelay(t *testing.T) {
+	// Base delay is 500ms
+	// Max delay is 30s
+	
+	tests := []struct {
+		attempt  int
+		expected time.Duration
+	}{
+		{0, 500 * time.Millisecond},
+		{1, 500 * time.Millisecond},
+		{2, 1000 * time.Millisecond},
+		{3, 2000 * time.Millisecond},
+		{4, 4000 * time.Millisecond},
+		{5, 8000 * time.Millisecond},
+		{6, 16000 * time.Millisecond},
+		{7, 30000 * time.Millisecond}, // Capped at 30s
+		{10, 30000 * time.Millisecond}, // Capped at 30s
+	}
+
+	for _, tc := range tests {
+		actual := backoffDelay(tc.attempt)
+		assert.Equal(t, tc.expected, actual, "attempt %d", tc.attempt)
+	}
+}


### PR DESCRIPTION
Closes #679 

Most of the requirements have been implemented in previous commits
EventClient Tests have been implemented in tray/events_test.go
ConnectionManager Tests have been in tray/connection_tests.go

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unit test for backoffDelay to verify exponential backoff (500ms base) with a 30s cap across attempts. Satisfies #679 by covering connection retry timing for reconnection logic.

<sup>Written for commit fafe4ae4d0352e2d608125684b124b22c1e91e29. Summary will update on new commits. <a href="https://cubic.dev/pr/blinklabs-io/adder/pull/720?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

