### PR TITLE
fix(ci): fix cross-platform tray build failures in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,7 +73,7 @@ jobs:
             os: windows
             arch: amd64
             tray: true
-          - runner: windows-latest
+          - runner: windows-11-arm
             os: windows
             arch: arm64
             tray: true
@@ -106,8 +106,22 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.os == 'linux' && matrix.tray
         run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxxf86vm-dev
+          if [ "${{ matrix.arch }}" = "arm64" ]; then
+            sudo dpkg --add-architecture arm64
+            sudo apt-get update
+            sudo apt-get install -y \
+              gcc-aarch64-linux-gnu \
+              libgl1-mesa-dev:arm64 \
+              libx11-dev:arm64 \
+              libxcursor-dev:arm64 \
+              libxrandr-dev:arm64 \
+              libxinerama-dev:arm64 \
+              libxi-dev:arm64 \
+              libxxf86vm-dev:arm64
+          else
+            sudo apt-get update
+            sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxxf86vm-dev
+          fi
 
       - name: Install FreeBSD tray build toolchain
         if: matrix.os == 'freebsd' && matrix.tray
@@ -131,6 +145,10 @@ jobs:
           if [ "${{ matrix.tray }}" = "true" ]; then
             if [ "${{ matrix.os }}" = "freebsd" ]; then
               "$(go env GOPATH)/bin/fyne-cross" freebsd -arch=${{ matrix.arch }} -name adder-tray -icon .github/assets/adder-logo-with-buffer.png -env GOTOOLCHAIN=auto ./cmd/adder-tray
+            elif [ "${{ matrix.os }}" = "linux" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
+              CC=aarch64-linux-gnu-gcc \
+                PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
+                GOOS=linux GOARCH=arm64 make build-tray
             else
               GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build-tray
             fi


### PR DESCRIPTION
- Use windows-11-arm runner for windows/arm64 so CGO_ENABLED=1 compiles natively instead of cross-compiling with an x86-64 assembler
- Install gcc-aarch64-linux-gnu and :arm64 GL/X11 dev libs for linux/arm64 tray builds, and pass CC/PKG_CONFIG_PATH to make build-tray

Ref: https://docs.github.com/en/actions/reference/runners/github-hosted-runners#standard-github-hosted-runners-for-public-repositories

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tray build failures in the publish workflow for Windows ARM and Linux arm64 by using a native Windows ARM runner and configuring an arm64 toolchain on Linux.

- **Bug Fixes**
  - Windows/arm64: switch to `windows-11-arm` runner to build natively with CGO and avoid x86-64 assembler errors.
  - Linux/arm64: install `gcc-aarch64-linux-gnu` and arm64 GL/X11 dev libs (`libgl1-mesa-dev:arm64`, `libx11-dev:arm64`, etc.); build with `CC=aarch64-linux-gnu-gcc` and `PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig`.

<sup>Written for commit 865c11877124b84e734f3477ec48ccc8a6f0bc8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added support for building on Windows 11 ARM architecture.
  * Enhanced Linux ARM64 build support with optimized dependency handling and compilation configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->