### PR TITLE
fix(ci): build Linux arm64 tray on native ARM runner

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,7 +65,7 @@ jobs:
             os: linux
             arch: amd64
             tray: true
-          - runner: ubuntu-latest
+          - runner: ubuntu-24.04-arm
             os: linux
             arch: arm64
             tray: true
@@ -106,22 +106,8 @@ jobs:
       - name: Install Linux dependencies
         if: matrix.os == 'linux' && matrix.tray
         run: |
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            sudo dpkg --add-architecture arm64
-            sudo apt-get update
-            sudo apt-get install -y \
-              gcc-aarch64-linux-gnu \
-              libgl1-mesa-dev:arm64 \
-              libx11-dev:arm64 \
-              libxcursor-dev:arm64 \
-              libxrandr-dev:arm64 \
-              libxinerama-dev:arm64 \
-              libxi-dev:arm64 \
-              libxxf86vm-dev:arm64
-          else
-            sudo apt-get update
-            sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxxf86vm-dev
-          fi
+          sudo apt-get update
+          sudo apt-get install -y gcc libgl1-mesa-dev xorg-dev libxcursor-dev libxrandr-dev libxinerama-dev libxi-dev libxxf86vm-dev
 
       - name: Install FreeBSD tray build toolchain
         if: matrix.os == 'freebsd' && matrix.tray
@@ -145,10 +131,6 @@ jobs:
           if [ "${{ matrix.tray }}" = "true" ]; then
             if [ "${{ matrix.os }}" = "freebsd" ]; then
               "$(go env GOPATH)/bin/fyne-cross" freebsd -arch=${{ matrix.arch }} -name adder-tray -icon .github/assets/adder-logo-with-buffer.png -env GOTOOLCHAIN=auto ./cmd/adder-tray
-            elif [ "${{ matrix.os }}" = "linux" ] && [ "${{ matrix.arch }}" = "arm64" ]; then
-              CC=aarch64-linux-gnu-gcc \
-                PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig \
-                GOOS=linux GOARCH=arm64 make build-tray
             else
               GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build-tray
             fi


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Build the Linux arm64 tray on a native ARM runner to fix cross-compile issues and simplify CI. Switches the matrix to `ubuntu-24.04-arm` and uses standard Linux deps and build path.

- **Bug Fixes**
  - Use `ubuntu-24.04-arm` runner for Linux arm64 tray builds.
  - Remove multi-arch apt setup and `aarch64-linux-gnu` toolchain; install standard X/GL deps only.
  - Drop arm64-specific build flags and rely on the default `make build-tray`.

<sup>Written for commit b8116085e20140be9220a248336a657afc5b695a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated build infrastructure for Linux ARM64 architecture to use dedicated build runner.
  * Simplified and standardized Linux dependency installation process for more consistent builds.
  * Streamlined build workflow to improve release consistency across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->