### PR TITLE
fix(ci): build Windows arm64 tray on native runner with MSYS2 CGO

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,6 +103,26 @@ jobs:
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 https://github.com/actions/setup-go/releases/tag/v6.4.0
         with:
           go-version: 1.26.x
+      - name: Set up MSYS2 MinGW64 for Windows amd64 CGO
+        if: matrix.os == 'windows' && matrix.arch == 'amd64' && matrix.tray
+        id: msys2-amd64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: >-
+            mingw-w64-x86_64-gcc
+
+      - name: Set up MSYS2 clangarm64 for Windows arm64 CGO
+        if: matrix.os == 'windows' && matrix.arch == 'arm64' && matrix.tray
+        id: msys2-arm64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: CLANGARM64
+          update: true
+          install: >-
+            mingw-w64-clang-aarch64-clang
+
       - name: Install Linux dependencies
         if: matrix.os == 'linux' && matrix.tray
         run: |
@@ -120,6 +140,25 @@ jobs:
         run: |
           $env:GOOS = "${{ matrix.os }}"
           $env:GOARCH = "${{ matrix.arch }}"
+
+          if ("${{ matrix.arch }}" -eq "amd64") {
+            $msys2Loc = "${{ steps.msys2-amd64.outputs.msys2-location }}"
+            $env:CC = "$msys2Loc\mingw64\bin\gcc.exe"
+            $env:CXX = "$msys2Loc\mingw64\bin\g++.exe"
+
+            go env GOOS GOARCH CC CXX
+            & $env:CC --version
+          }
+
+          if ("${{ matrix.arch }}" -eq "arm64") {
+            $msys2Loc = "${{ steps.msys2-arm64.outputs.msys2-location }}"
+            $env:CC = "$msys2Loc\clangarm64\bin\clang.exe"
+            $env:CXX = "$msys2Loc\clangarm64\bin\clang++.exe"
+
+            go env GOOS GOARCH CC CXX
+            & $env:CC --version
+          }
+
           make build
           if ("${{ matrix.tray }}" -eq "true") {
             make build-tray

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,9 @@ GOMODULE=$(shell grep ^module $(ROOT_DIR)/go.mod | awk '{ print $$2 }')
 # Set version strings based on git tag and current ref
 GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(shell git describe --tags --exact-match 2>/dev/null)' -X '$(GOMODULE)/internal/version.CommitHash=$(shell git rev-parse --short HEAD)'"
 
+GO_CGO_CFLAGS=$(shell go env CGO_CFLAGS)
+TRAY_CGO_CFLAGS=$(strip $(GO_CGO_CFLAGS) $(if $(filter windows/arm64,$(GOOS)/$(GOARCH)),-DWINBOOL=BOOL,))
+
 .PHONY: build build-tray mod-tidy clean test bundle-macos
 
 # Alias for building program binary
@@ -46,7 +49,7 @@ test: mod-tidy
 # Build adder-tray binary
 # CGO is required on all platforms for Fyne UI support.
 build-tray: mod-tidy $(GO_FILES)
-	CGO_ENABLED=1 go build \
+	CGO_CFLAGS="$(TRAY_CGO_CFLAGS)" CGO_ENABLED=1 go build \
 		$(GO_LDFLAGS) \
 		-o adder-tray$(if $(filter windows,$(GOOS)),.exe,) \
 		./cmd/adder-tray


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CI to build and test Windows amd64 and arm64 with MSYS2 and CGO, covering both main and tray; the Windows arm64 tray builds on the native `windows-11-arm` runner using CLANGARM64.

`publish.yml` installs MSYS2 toolchains and exports `CC`/`CXX` from the action’s `msys2-location`; the `Makefile` forwards `CGO_CFLAGS` and adds `-DWINBOOL=BOOL` for the `windows/arm64` tray.

<sup>Written for commit 3809ca1a60d22c86c8810e5c652b5cd8615b7206. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Windows build testing workflow for multiple processor architectures to enhance build verification across platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->