### PR TITLE
chore(ci): update Java version to 21 for Windows signing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -181,7 +181,7 @@ jobs:
         uses: actions/setup-java@ad2b38190b15e4d6bdf0c97fb4fca8412226d287 # v5.3.0 https://github.com/actions/setup-java/releases/tag/v5.3.0
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' }}
         with:
-          java-version: 17
+          java-version: 21
           distribution: 'temurin'
       - id: 'auth'
         name: Authenticate with Google Cloud


### PR DESCRIPTION
Closes: #758 

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Update the publish workflow to use Java 21 (Temurin) for Windows signing so tagged releases sign successfully. Fixes signing failures caused by Java 17 incompatibility with the current toolchain.

<sup>Written for commit feb645c6c8244b83e227a82dba336f604e1939c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/759?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

