### PR TITLE
feat(tray): in-app notification rule editor

### DIFF
--- a/tray/app.go
+++ b/tray/app.go
@@ -179,41 +179,28 @@ func (a *App) onWizardFinish(
 ) {
 	slog.Info("wizard finished, running setup tasks")
 
+	enable := func() {
+		if ctrl != nil {
+			ctrl.EnableButtons()
+		}
+	}
+	var parent fyne.Window
+	if ctrl != nil {
+		parent = ctrl.Window()
+	}
+
 	go func() {
-		result, err := a.runner.Apply(ctx, plan)
+		result, err := a.applyPlan(ctx, plan)
 		if err != nil {
-			a.failTask("Failed to apply configuration", err, ctrl)
+			a.failTask("Failed to apply configuration", err, parent, enable)
 			return
 		}
-		// Surface soft errors to the user — the config is saved, but
-		// the service may not be running because the binary was not
-		// found or the restart failed. Without this the wizard reports
-		// "Setup Complete" and the user is left to discover the silent
-		// failure via a later "API unreachable" error with no context.
-		if result.HasSoftErrors() {
-			a.surfaceSoftApplyErrors(result, ctrl)
-		}
-		if cfg, err := a.runner.Store.LoadTray(); err != nil {
-			slog.Warn("failed to reload tray config after setup", "error", err)
-		} else {
-			a.configMu.Lock()
-			a.config = cfg
-			a.configMu.Unlock()
+		// Keep the wizard open with re-enabled inputs so the warning
+		// dialog (a modal child of the wizard) has a stable parent.
+		if a.handleSoftErrors(result, parent, enable) {
+			return
 		}
 
-		// Rebuild rules + push new rate-limit knobs so changes take
-		// effect without a tray restart. On first run the engine
-		// isn't yet constructed (setupTray runs later) — it picks up
-		// both at construction time.
-		if eng := a.notifyEngine.Load(); eng != nil {
-			eng.SetRules(
-				notifications.RulesFromPlan(a.notifyPlan()),
-			)
-			limit, window := a.Config().ResolvedNotifyRate()
-			eng.SetRateLimit(limit, window)
-		}
-
-		// Success!
 		fyne.Do(func() {
 			if ctx.Err() != nil {
 				return
@@ -240,6 +227,37 @@ func (a *App) onWizardFinish(
 	}()
 }
 
+// applyPlan persists a SetupPlan and hot-reloads the running tray:
+// runs SetupRunner.Apply, refreshes the cached tray config from the
+// returned snapshot, and swaps the engine's rule set + rate-limit.
+// err != nil signals a pre-save failure (load + save steps); post-save
+// problems are non-fatal soft errors on ApplyResult, so when err != nil
+// nothing was persisted and there is nothing to reconcile.
+func (a *App) applyPlan(
+	ctx context.Context, plan setup.SetupPlan,
+) (setup.ApplyResult, error) {
+	result, err := a.runner.Apply(ctx, plan)
+	if err != nil {
+		return result, err
+	}
+	a.configMu.Lock()
+	a.config = result.TrayConfig
+	a.configMu.Unlock()
+	// Rate limit comes from the persisted snapshot; rules come from
+	// the input plan (the runner deep-copies plan.Filter+plan.Notify
+	// into trayCfg, so they describe the same state — adding
+	// canonicalization to SaveTrayAtomic would require deriving a
+	// SetupPlan from the snapshot here for RulesFromPlan to keep up).
+	// notifyEngine is nil on first run (setupTray runs after
+	// onWizardFinish) and picks up rules + limits at construction.
+	if eng := a.notifyEngine.Load(); eng != nil {
+		eng.SetRules(notifications.RulesFromPlan(plan))
+		limit, window := result.TrayConfig.ResolvedNotifyRate()
+		eng.SetRateLimit(limit, window)
+	}
+	return result, nil
+}
+
 // Config returns a consistent snapshot of the current tray configuration.
 // It is safe to call from any goroutine.
 func (a *App) Config() TrayConfig {
@@ -249,54 +267,183 @@ func (a *App) Config() TrayConfig {
 }
 
 // surfaceSoftApplyErrors shows a warning dialog summarising the
-// non-fatal errors Apply returned. The config IS saved at this point —
-// we just need the user to know the running service may not reflect
-// it so they can act (install adder, restart the service, etc.). The
-// wizard is not failed; the user can still close it and proceed.
+// non-fatal errors Apply returned. The config IS saved; the source
+// surface stays open so the user can read the warning and decide
+// whether to retry or close.
 func (a *App) surfaceSoftApplyErrors(
-	result setup.ApplyResult, ctrl *wizard.WizardController,
+	result setup.ApplyResult, parent fyne.Window,
 ) {
-	var msg string
-	if result.BinaryFindErr != nil {
-		msg += "Could not find the adder binary: " +
-			result.BinaryFindErr.Error() +
-			"\nThe service was not (re)started; install adder " +
-			"or start it manually."
+	// Each paragraph is gated on a per-error predicate so the
+	// composition stays data-driven: adding a fourth soft category
+	// is one entry, not another open-coded if + msg-glue block. The
+	// ReconnectErr predicate suppresses it when Binary/Restart fired
+	// — those root causes are already explained above and they
+	// directly imply Reconnect will fail; repeating "service may be
+	// starting up, try again" would mislead the user (nothing was
+	// asked to start).
+	paragraphs := []struct {
+		when bool
+		body string
+	}{
+		{
+			when: result.BinaryFindErr != nil,
+			body: "Could not find the adder binary: " +
+				errString(result.BinaryFindErr) +
+				"\nThe service was not (re)started; install " +
+				"adder or start it manually.",
+		},
+		{
+			when: result.ServiceRestartErr != nil,
+			body: "Failed to (re)start the adder service: " +
+				errString(result.ServiceRestartErr) +
+				"\nThe running process may not reflect your new " +
+				"configuration; restart adder manually.",
+		},
+		{
+			when: result.ReconnectErr != nil &&
+				result.BinaryFindErr == nil &&
+				result.ServiceRestartErr == nil,
+			body: "Adder API not reachable yet: " +
+				errString(result.ReconnectErr) +
+				"\nThe config is saved; the service may still be " +
+				"starting up. Try again in a moment if status " +
+				"does not recover.",
+		},
 	}
-	if result.ServiceRestartErr != nil {
-		if msg != "" {
-			msg += "\n\n"
+	var parts []string
+	for _, p := range paragraphs {
+		if p.when {
+			parts = append(parts, p.body)
 		}
-		msg += "Failed to (re)start the adder service: " +
-			result.ServiceRestartErr.Error() +
-			"\nThe running process may not reflect your new " +
-			"configuration; restart adder manually."
 	}
+	if len(parts) == 0 {
+		return
+	}
+	msg := strings.Join(parts, "\n\n")
 	slog.Warn("setup completed with soft errors", "summary", msg)
 	fyne.Do(func() {
-		if ctrl != nil {
-			ctrl.EnableButtons()
+		win := a.resolveDialogParent(parent)
+		if win == nil {
+			return
 		}
-		if len(a.fyneApp.Driver().AllWindows()) > 0 {
-			dialog.ShowInformation(
-				"Setup Complete (with warnings)",
-				msg,
-				a.fyneApp.Driver().AllWindows()[0],
-			)
-		}
+		dialog.ShowInformation(
+			"Setup Complete (with warnings)", msg, win)
 	})
 }
 
-func (a *App) failTask(msg string, err error, ctrl *wizard.WizardController) {
+// resolveDialogParent returns the explicit parent window when given,
+// else falls back to the first window the Fyne driver still tracks.
+// Returns nil when no window is available (dialog drops silently —
+// slog.* already records the underlying event).
+func (a *App) resolveDialogParent(parent fyne.Window) fyne.Window {
+	if parent != nil {
+		return parent
+	}
+	if wins := a.fyneApp.Driver().AllWindows(); len(wins) > 0 {
+		return wins[0]
+	}
+	return nil
+}
+
+// handleSoftErrors surfaces the warning dialog and re-enables the
+// caller's frozen inputs when result has soft errors; the source
+// surface stays open so the dialog has a stable parent and the user
+// can retry. Returns true when soft errors fired (caller skips its
+// success path), false otherwise.
+func (a *App) handleSoftErrors(
+	result setup.ApplyResult, parent fyne.Window, enable func(),
+) bool {
+	if !result.HasSoftErrors() {
+		return false
+	}
+	a.surfaceSoftApplyErrors(result, parent)
+	if enable != nil {
+		fyne.Do(enable)
+	}
+	return true
+}
+
+// errString returns err.Error() or "" for nil — keeps surfaceSoft's
+// data table free of per-row nil checks.
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// failTask logs the error, re-enables the caller's frozen inputs via
+// onFail, and shows an error dialog on the first available window.
+// AllWindows()[0] is best-effort: a concurrently-closing source
+// surface lands the dialog on whichever window Fyne still tracks;
+// when none remains the dialog drops silently (slog.Error already
+// records the failure).
+func (a *App) failTask(
+	msg string, err error, parent fyne.Window, onFail func(),
+) {
 	slog.Error(msg, "error", err)
 	fyne.Do(func() {
-		if ctrl != nil {
-			ctrl.EnableButtons()
+		if onFail != nil {
+			onFail()
 		}
-		if len(a.fyneApp.Driver().AllWindows()) > 0 {
-			dialog.ShowError(errors.New(msg+"\n\nError: "+err.Error()), a.fyneApp.Driver().AllWindows()[0])
+		win := a.resolveDialogParent(parent)
+		if win == nil {
+			return
 		}
+		dialog.ShowError(
+			errors.New(msg+"\n\nError: "+err.Error()), win)
 	})
+}
+
+// onRulesApply is the apply callback for the rule editor: persists
+// via applyPlan, surfaces hard errors via failTask and soft errors
+// via handleSoftErrors; on full success closes the editor and emits a
+// tray notification.
+func (a *App) onRulesApply(
+	ctx context.Context,
+	plan setup.SetupPlan,
+	ed *wizard.RulesEditor,
+) {
+	slog.Info("notification rules edited, applying changes")
+
+	enable := func() {
+		if ed != nil {
+			ed.EnableButtons()
+		}
+	}
+	var parent fyne.Window
+	if ed != nil {
+		parent = ed.Window()
+	}
+
+	go func() {
+		result, err := a.applyPlan(ctx, plan)
+		if err != nil {
+			a.failTask("Failed to apply notification rules",
+				err, parent, enable)
+			return
+		}
+		// Soft errors: shared with onWizardFinish via handleSoftErrors
+		// — keeps the editor open with re-enabled inputs so the
+		// warning dialog (a modal child of the editor) has a stable
+		// parent.
+		if a.handleSoftErrors(result, parent, enable) {
+			return
+		}
+
+		fyne.Do(func() {
+			if ctx.Err() != nil {
+				return
+			}
+			if ed != nil {
+				ed.Close()
+			}
+			a.fyneApp.SendNotification(fyne.NewNotification(
+				"Adder Rules Updated",
+				"Notification rules applied.",
+			))
+		})
+	}()
 }
 
 // Run configures the system tray and starts the application loop.
@@ -368,6 +515,17 @@ func (a *App) setupTray() {
 		wizard.ShowWizard(&plan, a.onWizardFinish)
 	})
 
+	mRules := fyne.NewMenuItem("Notification Rules...", func() {
+		plan, err := a.reconfigurePlan()
+		if err != nil {
+			slog.Error("failed to load engine config for rules editor",
+				"error", err)
+			return
+		}
+
+		wizard.ShowRulesEditor(plan, a.onRulesApply)
+	})
+
 	mShowConfig := fyne.NewMenuItem("Show Config Folder", func() {
 		openFolder(ConfigDir())
 	})
@@ -395,6 +553,7 @@ func (a *App) setupTray() {
 		mStop,
 		mRestart,
 		mReconfigure,
+		mRules,
 		fyne.NewMenuItemSeparator(),
 		mShowConfig,
 		mShowLogs,

--- a/tray/notifications/rules_test.go
+++ b/tray/notifications/rules_test.go
@@ -754,3 +754,41 @@ func TestRulesFromPlan_MultiKindORSemantics(t *testing.T) {
 		anyRuleMatches(rules, txWithTokens([2]string{"polA", "asset1abc"})),
 		"asset rule fires independent of other kinds")
 }
+
+// TestAllNotifyPrefsHaveEngineRule pins setup.AllNotifyPrefs to the
+// rules.go enumeration: for each pref, enabling it (plus a target so
+// per-target rules fire) must produce at least one Enabled=true rule.
+// If a new pref is added to AllNotifyPrefs without a matching case
+// here in rules.go, this test fails — preventing the editor toggle
+// from being a silent no-op.
+func TestAllNotifyPrefsHaveEngineRule(t *testing.T) {
+	// Use one target of every kind so per-target rule families
+	// (walletRules, drepRules, poolRules, assetRules, policyRules)
+	// have something to fan out over.
+	baseFilter := setup.FilterConfig{
+		Wallets:  []string{"addr1qxy"},
+		DReps:    []string{"drep1abc"},
+		Pools:    []string{"pool1xyz"},
+		Assets:   []string{"asset1abc"},
+		Policies: []string{"polA"},
+	}
+	for _, pref := range setup.AllNotifyPrefs() {
+		t.Run(pref, func(t *testing.T) {
+			plan := setup.SetupPlan{
+				Filter: baseFilter,
+				Notify: setup.NotificationPrefs{pref: true},
+			}
+			rules := RulesFromPlan(plan)
+			var enabled int
+			for _, r := range rules {
+				if r.Enabled {
+					enabled++
+				}
+			}
+			require.Greaterf(t, enabled, 0,
+				"pref %q produced no enabled rules — add coverage in "+
+					"rules.go or remove from setup.AllNotifyPrefs",
+				pref)
+		})
+	}
+}

--- a/tray/setup/plan.go
+++ b/tray/setup/plan.go
@@ -18,6 +18,8 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
+	"slices"
 	"strings"
 	"time"
 )
@@ -49,6 +51,34 @@ const (
 	// alerts.
 	NotifyPrefConnectionIssues = "Connection issues"
 )
+
+// allNotifyPrefs is the canonical ordering of every NotifyPref* used
+// across the rules editor, the wizard's notifications step, and rule
+// derivation. Order groups chain activity first, then governance,
+// then asset/policy, then connection. Unexported so importers cannot
+// reassign or mutate in place — use AllNotifyPrefs() to read.
+var allNotifyPrefs = []string{
+	NotifyPrefIncomingTx,
+	NotifyPrefOutgoingTx,
+	NotifyPrefTokenTransfers,
+	NotifyPrefBlocksMinted,
+	NotifyPrefPoolParams,
+	NotifyPrefGovProposals,
+	NotifyPrefVotesCast,
+	NotifyPrefRegChanges,
+	NotifyPrefAssetActivity,
+	NotifyPrefPolicyActivity,
+	NotifyPrefConnectionIssues,
+}
+
+// AllNotifyPrefs returns the canonical ordering of every NotifyPref*
+// as a fresh slice; the backing array is private so callers cannot
+// corrupt the order. New prefs must be added to allNotifyPrefs so
+// every surface enumerates the same set; TestAllNotifyPrefsExhaustive
+// guards against drift between this list and the NotifyPref* consts.
+func AllNotifyPrefs() []string {
+	return slices.Clone(allNotifyPrefs)
+}
 
 // SetupPlan represents the desired configuration state of the Adder ecosystem,
 // decoupled from UI display strings and engine-specific map structures.
@@ -92,6 +122,25 @@ func CloneFilter(f FilterConfig) FilterConfig {
 	out.Pools = append([]string(nil), f.Pools...)
 	out.Assets = append([]string(nil), f.Assets...)
 	out.Policies = append([]string(nil), f.Policies...)
+	return out
+}
+
+// ClonePlan returns a deep copy of p whose reference-typed fields
+// (Filter slices, Notify map, Output.Config map) are independent, so a
+// caller can mutate its copy without touching the source. Centralised
+// here next to CloneFilter so adding a new reference-typed field to
+// SetupPlan updates exactly one place.
+func ClonePlan(p SetupPlan) SetupPlan {
+	out := p
+	out.Filter = CloneFilter(p.Filter)
+	if p.Notify != nil {
+		out.Notify = make(NotificationPrefs, len(p.Notify))
+		maps.Copy(out.Notify, p.Notify)
+	}
+	if p.Output.Config != nil {
+		out.Output.Config = make(map[string]string, len(p.Output.Config))
+		maps.Copy(out.Output.Config, p.Output.Config)
+	}
 	return out
 }
 

--- a/tray/setup/plan_test.go
+++ b/tray/setup/plan_test.go
@@ -1,0 +1,98 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestClonePlanIsDeep(t *testing.T) {
+	orig := SetupPlan{
+		Filter: FilterConfig{
+			Wallets:  []string{"addr1a"},
+			DReps:    []string{"drep1a"},
+			Pools:    []string{"pool1a"},
+			Assets:   []string{"asset1a"},
+			Policies: []string{"pol1a"},
+		},
+		Notify: NotificationPrefs{NotifyPrefIncomingTx: true},
+		Output: OutputConfig{Config: map[string]string{"k": "v"}},
+	}
+	clone := ClonePlan(orig)
+	clone.Filter.Wallets = append(clone.Filter.Wallets, "addr1b")
+	clone.Filter.DReps[0] = "drep1z"
+	clone.Notify[NotifyPrefIncomingTx] = false
+	clone.Notify[NotifyPrefOutgoingTx] = true
+	clone.Output.Config["k"] = "other"
+
+	assert.Equal(t, []string{"addr1a"}, orig.Filter.Wallets)
+	assert.Equal(t, "drep1a", orig.Filter.DReps[0])
+	assert.True(t, orig.Notify[NotifyPrefIncomingTx])
+	_, hasOutgoing := orig.Notify[NotifyPrefOutgoingTx]
+	assert.False(t, hasOutgoing)
+	assert.Equal(t, "v", orig.Output.Config["k"])
+}
+
+func TestClonePlanNilMapsStaySafe(t *testing.T) {
+	// Nil maps/slices must not panic and must not allocate empty
+	// non-nil maps that would surprise callers checking for nil.
+	orig := SetupPlan{}
+	clone := ClonePlan(orig)
+	assert.Nil(t, clone.Notify)
+	assert.Nil(t, clone.Output.Config)
+}
+
+// TestAllNotifyPrefsExhaustive asserts AllNotifyPrefs lists every
+// NotifyPref* constant declared in plan.go exactly once. Locks in
+// the single-source-of-truth invariant so adding a new pref forces
+// updating AllNotifyPrefs (otherwise the rules editor silently
+// hides the toggle).
+func TestAllNotifyPrefsExhaustive(t *testing.T) {
+	want := []string{
+		NotifyPrefBlocksMinted,
+		NotifyPrefIncomingTx,
+		NotifyPrefOutgoingTx,
+		NotifyPrefTokenTransfers,
+		NotifyPrefGovProposals,
+		NotifyPrefVotesCast,
+		NotifyPrefRegChanges,
+		NotifyPrefPoolParams,
+		NotifyPrefAssetActivity,
+		NotifyPrefPolicyActivity,
+		NotifyPrefConnectionIssues,
+	}
+	got := AllNotifyPrefs()
+	require.Len(t, got, len(want))
+	seen := make(map[string]struct{}, len(got))
+	for _, p := range got {
+		_, dup := seen[p]
+		assert.False(t, dup, "pref %q listed twice", p)
+		seen[p] = struct{}{}
+	}
+	for _, p := range want {
+		_, ok := seen[p]
+		assert.Truef(t, ok, "AllNotifyPrefs missing %q", p)
+	}
+	// Accessor returns a fresh slice — mutating it must not affect
+	// the canonical backing array.
+	require.NotEmpty(t, got)
+	got[0] = "X"
+	again := AllNotifyPrefs()
+	require.NotEmpty(t, again)
+	assert.NotEqual(t, "X", again[0])
+}

--- a/tray/setup/runner.go
+++ b/tray/setup/runner.go
@@ -16,6 +16,7 @@ package setup
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -49,6 +50,12 @@ type BinaryFinder interface {
 // callers can surface them to the user. Apply still succeeds (config
 // is saved) but the running service may not reflect the change.
 type ApplyResult struct {
+	// TrayConfig is the snapshot just persisted by Apply, returned to
+	// callers so they can refresh in-memory caches without re-reading
+	// from disk. Populated as soon as SaveTrayAtomic succeeds, before
+	// any service / reconnect step runs. NotifyPrefs map and Filter
+	// slices alias the persisted snapshot — treat as read-only.
+	TrayConfig TrayConfig
 	// BinaryFindErr is non-nil when Finder.Find failed; the service
 	// was NOT (re)started.
 	BinaryFindErr error
@@ -56,12 +63,20 @@ type ApplyResult struct {
 	// to (re)start adder; the running process may not reflect the
 	// new config.
 	ServiceRestartErr error
+	// ReconnectErr is non-nil when the post-restart Reconnect to the
+	// running adder API failed. The config IS persisted and the
+	// service WAS asked to (re)start; the API just is not reachable
+	// yet (slow startup, port collision, firewall). Soft so the
+	// caller can surface it without rolling back the apply.
+	ReconnectErr error
 }
 
 // HasSoftErrors reports whether the result carries any non-fatal
 // error worth surfacing to the user.
 func (r ApplyResult) HasSoftErrors() bool {
-	return r.BinaryFindErr != nil || r.ServiceRestartErr != nil
+	return r.BinaryFindErr != nil ||
+		r.ServiceRestartErr != nil ||
+		r.ReconnectErr != nil
 }
 
 func (r *SetupRunner) Apply(
@@ -102,6 +117,9 @@ func (r *SetupRunner) Apply(
 	if err := r.Store.SaveTrayAtomic(trayCfg); err != nil {
 		return result, fmt.Errorf("saving tray config: %w", err)
 	}
+	// Expose the persisted snapshot so callers refresh in-memory
+	// caches without a disk round-trip.
+	result.TrayConfig = trayCfg
 
 	// 4. Service Management — Finder/Restart failures are soft and
 	// surfaced via ApplyResult; the config is already persisted.
@@ -124,30 +142,35 @@ func (r *SetupRunner) Apply(
 	r.Conn.SetAddress(trayCfg.APIAddress)
 	r.Conn.SetPort(trayCfg.APIPort)
 
-	// Give the service a moment to start
+	// Give the service a moment to start. A deadline-exceeded ctx
+	// is a real "we never got to verify" signal (caller imposed a
+	// hard cap that we hit), so it surfaces as ReconnectErr. A
+	// user-driven cancel (Canceled) means the caller walked away and
+	// no longer wants UI feedback — config IS persisted and the
+	// caller's own reconcile already ran, so we exit silently.
 	select {
 	case <-ctx.Done():
-		return result, ctx.Err()
+		if cause := ctx.Err(); errors.Is(cause, context.DeadlineExceeded) {
+			result.ReconnectErr = fmt.Errorf(
+				"timed out before adder API was reachable: %w",
+				cause)
+			slog.Warn("apply post-save wait timed out",
+				"error", result.ReconnectErr)
+		}
+		return result, nil
 	case <-time.After(1 * time.Second):
 	}
 
 	if err := r.Conn.Reconnect(); err != nil {
-		// Wrap with the soft-error context so the message names the
-		// root cause, not just the downstream symptom.
-		if result.BinaryFindErr != nil {
-			return result, fmt.Errorf(
-				"service registered but API is unreachable "+
-					"(binary not found: %w): %w",
-				result.BinaryFindErr, err)
-		}
-		if result.ServiceRestartErr != nil {
-			return result, fmt.Errorf(
-				"service registered but API is unreachable "+
-					"(restart failed: %w): %w",
-				result.ServiceRestartErr, err)
-		}
-		return result, fmt.Errorf(
-			"service registered but API is unreachable: %w", err)
+		// Reconnect failure is soft: persistence already ran. Keep
+		// the error standalone — Binary/Restart causes are already
+		// surfaced as their own soft fields, so wrapping them here
+		// would make the caller's dialog repeat the same root-cause
+		// text twice. Also avoid claiming "service registered" when
+		// BinaryFindErr fired (RestartIfConfigChanged was skipped).
+		result.ReconnectErr = fmt.Errorf(
+			"adder API is unreachable: %w", err)
+		slog.Warn("api unreachable after apply", "error", result.ReconnectErr)
 	}
 
 	return result, nil

--- a/tray/setup/runner_test.go
+++ b/tray/setup/runner_test.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/blinklabs-io/adder/internal/config"
 	"github.com/stretchr/testify/assert"
@@ -279,11 +280,13 @@ func TestApplyReturnsBinaryFindAsApplyResult(t *testing.T) {
 	assert.ErrorIs(t, result.BinaryFindErr, wantErr)
 }
 
-// TestApplyReconnectErrWrapsSoftErrors guards that a binary-find or
-// restart failure followed by an "API unreachable" error produces a
-// composite message naming the root cause, not just the downstream
-// symptom.
-func TestApplyReconnectErrWrapsSoftErrors(t *testing.T) {
+// TestApplyReconnectErrIsStandaloneSoft guards that Reconnect failure
+// surfaces as a standalone soft error: it must NOT wrap BinaryFindErr
+// or ServiceRestartErr (those are already separate soft fields, so
+// embedding them here would make the caller's dialog repeat the same
+// root cause twice and falsely claim the service was registered).
+// Apply still returns nil because the config IS persisted.
+func TestApplyReconnectErrIsStandaloneSoft(t *testing.T) {
 	wantBin := errors.New("not on PATH")
 	wantReconnect := errors.New("dial tcp: no route")
 	runner := &SetupRunner{
@@ -292,18 +295,33 @@ func TestApplyReconnectErrWrapsSoftErrors(t *testing.T) {
 		Conn:    &mockConnector{reconnectErr: wantReconnect},
 		Finder:  &mockFinder{err: wantBin},
 	}
-	_, err := runner.Apply(context.Background(), SetupPlan{
+	result, err := runner.Apply(context.Background(), SetupPlan{
 		Network: NetworkConfig{Name: "mainnet"},
 		Filter:  FilterConfig{MonitorEverything: true},
 	})
-	require.Error(t, err)
-	assert.ErrorIs(t, err, wantBin,
-		"composite error must preserve the binary-find cause")
-	assert.ErrorIs(t, err, wantReconnect,
-		"composite error must also preserve the reconnect cause")
+	require.NoError(t, err,
+		"Reconnect failure must not abort Apply — config IS saved")
+	require.Error(t, result.BinaryFindErr,
+		"BinaryFindErr must be surfaced separately")
+	require.Error(t, result.ReconnectErr,
+		"Reconnect failure must surface as its own soft error")
+	assert.ErrorIs(t, result.ReconnectErr, wantReconnect,
+		"ReconnectErr must preserve the underlying dial cause")
+	assert.NotErrorIs(t, result.ReconnectErr, wantBin,
+		"ReconnectErr must NOT wrap BinaryFindErr — would duplicate "+
+			"context and falsely claim service was registered")
+	assert.NotContains(t, result.ReconnectErr.Error(), "service registered",
+		"Reconnect message must not claim registration when "+
+			"BinaryFindErr skipped RestartIfConfigChanged")
+	assert.True(t, result.HasSoftErrors())
 }
 
-func TestApplyHonorsContextCancellationBeforeReconnect(t *testing.T) {
+// TestApplyContextCancellationSkipsReconnect verifies ctx cancellation
+// during the post-save wait skips Reconnect without aborting Apply —
+// the config IS persisted on disk, so the caller can still reconcile
+// in-memory state and the user-initiated cancel does not surface as a
+// failure.
+func TestApplyContextCancellationSkipsReconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -316,12 +334,43 @@ func TestApplyHonorsContextCancellationBeforeReconnect(t *testing.T) {
 		Finder:  &mockFinder{path: "/tmp/adder"},
 	}
 
-	_, err := runner.Apply(ctx, SetupPlan{
+	result, err := runner.Apply(ctx, SetupPlan{
 		Network: NetworkConfig{Name: "mainnet"},
 		Filter:  FilterConfig{MonitorEverything: true},
 	})
-	require.ErrorIs(t, err, context.Canceled)
-
+	require.NoError(t, err,
+		"ctx cancel post-save must not surface as a failure")
 	assert.True(t, store.saved)
-	assert.False(t, conn.connected)
+	assert.False(t, conn.connected,
+		"Reconnect must be skipped on ctx cancellation")
+	assert.Nil(t, result.ReconnectErr,
+		"user-driven Canceled must stay silent")
+}
+
+// TestApplyContextDeadlineSurfacesAsSoftReconnect guards that a hard
+// deadline hit during the post-save wait surfaces as a soft
+// ReconnectErr — the caller imposed a cap and we never got to verify
+// the API, so the user needs the signal (unlike user-driven Canceled
+// which is silent).
+func TestApplyContextDeadlineSurfacesAsSoftReconnect(t *testing.T) {
+	ctx, cancel := context.WithDeadline(context.Background(),
+		time.Now().Add(-time.Second))
+	defer cancel()
+
+	store := &mockStore{}
+	runner := &SetupRunner{
+		Store:   store,
+		Service: &mockService{},
+		Conn:    &mockConnector{},
+		Finder:  &mockFinder{path: "/tmp/adder"},
+	}
+	result, err := runner.Apply(ctx, SetupPlan{
+		Network: NetworkConfig{Name: "mainnet"},
+		Filter:  FilterConfig{MonitorEverything: true},
+	})
+	require.NoError(t, err,
+		"deadline post-save must not abort Apply — config IS saved")
+	require.Error(t, result.ReconnectErr)
+	assert.ErrorIs(t, result.ReconnectErr, context.DeadlineExceeded)
+	assert.True(t, result.HasSoftErrors())
 }

--- a/tray/wizard/rules_editor.go
+++ b/tray/wizard/rules_editor.go
@@ -1,0 +1,391 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"context"
+	"log/slog"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/app"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
+	"fyne.io/fyne/v2/layout"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+	"github.com/blinklabs-io/adder/tray/setup"
+)
+
+// RulesEditor is the post-setup notification rule editor: targets +
+// per-category prefs in one window, mutating a working copy that
+// Cancel discards and Apply hands to the callback. Shares
+// targetSection with the wizard's step 3 but sets onDelete to a
+// confirm dialog (the wizard keeps immediate-delete).
+type RulesEditor struct {
+	window fyne.Window
+
+	// working is the mutated copy of the plan; commit happens only on
+	// Apply via the callback. The original plan stays untouched so
+	// Cancel is a true no-op.
+	working  setup.SetupPlan
+	callback func(context.Context, setup.SetupPlan, *RulesEditor)
+
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	everythingCheck *widget.Check
+	targetsBox      *fyne.Container
+	sections        []*targetSection
+	wallets         *targetSection
+	dreps           *targetSection
+	pools           *targetSection
+	assets          *targetSection
+	policies        *targetSection
+
+	prefChecks map[string]*widget.Check
+
+	applyBtn *widget.Button
+	closeBtn *widget.Button
+
+	// applying is set true between onApply firing the callback and the
+	// caller releasing the editor (via EnableButtons on a soft / hard
+	// failure, or Close on success). While true the Cancel button and
+	// the window-close affordance are blocked so the user cannot tear
+	// down the warning dialog's parent mid-apply.
+	applying bool
+}
+
+// NewRulesEditor builds the rule-editor window for the given plan. The
+// callback is invoked on Apply with the mutated plan; it is responsible
+// for persistence/restart (see App.onRulesApply).
+func NewRulesEditor(
+	plan setup.SetupPlan,
+	callback func(context.Context, setup.SetupPlan, *RulesEditor),
+) *RulesEditor {
+	a := fyne.CurrentApp()
+	if a == nil {
+		a = app.New()
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	e := &RulesEditor{
+		working:    setup.ClonePlan(plan),
+		callback:   callback,
+		ctx:        ctx,
+		cancel:     cancel,
+		prefChecks: make(map[string]*widget.Check),
+	}
+
+	e.window = a.NewWindow("Adder Notification Rules")
+	e.window.Resize(fyne.NewSize(560, 640))
+	e.window.SetOnClosed(cancel)
+	// Block the native window-close affordance while apply is in
+	// flight so the warning dialog's parent cannot vanish under it.
+	e.window.SetCloseIntercept(func() {
+		if e.applying {
+			return
+		}
+		e.Close()
+	})
+
+	e.buildTargetSections()
+	prefsBox := e.buildPrefBox()
+
+	e.applyBtn = widget.NewButtonWithIcon(
+		"Apply & Restart",
+		theme.ConfirmIcon(),
+		e.onApply,
+	)
+	e.applyBtn.Importance = widget.HighImportance
+	e.closeBtn = widget.NewButton("Cancel", e.Close)
+
+	header := container.NewVBox(
+		widget.NewLabelWithStyle(
+			"Notification Rules",
+			fyne.TextAlignLeading,
+			fyne.TextStyle{Bold: true},
+		),
+		widget.NewLabel(
+			"Add or remove monitoring targets and toggle which "+
+				"event categories trigger desktop notifications. "+
+				"Apply writes the config and restarts Adder.",
+		),
+	)
+	footer := container.NewHBox(
+		layout.NewSpacer(),
+		e.closeBtn,
+		e.applyBtn,
+	)
+
+	body := container.NewVBox(
+		widget.NewLabelWithStyle(
+			"Monitoring Targets",
+			fyne.TextAlignLeading,
+			fyne.TextStyle{Bold: true},
+		),
+		e.everythingCheck,
+		e.targetsBox,
+		widget.NewSeparator(),
+		prefsBox,
+	)
+
+	e.window.SetContent(container.NewBorder(
+		header,
+		footer,
+		nil,
+		nil,
+		container.NewVScroll(body),
+	))
+	return e
+}
+
+// ShowRulesEditor launches the notification rule editor window.
+func ShowRulesEditor(
+	plan setup.SetupPlan,
+	callback func(context.Context, setup.SetupPlan, *RulesEditor),
+) {
+	slog.Debug("launching notification rules editor")
+	fyne.Do(func() {
+		e := NewRulesEditor(plan, callback)
+		e.window.CenterOnScreen()
+		e.window.Show()
+	})
+}
+
+// confirmDelete is the editor's onDelete policy: gate each row's
+// trash-button activation behind a confirm dialog rooted at the
+// editor window. sectionLabel names the right list in the dialog
+// title and body.
+func (e *RulesEditor) confirmDelete(sectionLabel string) func(string, func()) {
+	return func(v string, doDelete func()) {
+		dialog.ShowConfirm(
+			"Delete "+sectionLabel,
+			"Remove \""+v+"\" from "+sectionLabel+"?",
+			func(ok bool) {
+				if !ok {
+					return
+				}
+				doDelete()
+			},
+			e.window,
+		)
+	}
+}
+
+// buildTargetSections constructs the five reused targetSection widgets
+// and wires their onDelete to a confirm dialog so each row trash button
+// confirms before removing (vs. the wizard's immediate delete).
+// onChange refreshes the working filter snapshot.
+func (e *RulesEditor) buildTargetSections() {
+	mk := func(
+		label, placeholder string,
+		validate func(string) error,
+	) *targetSection {
+		sec := newTargetSection(label, placeholder, validate,
+			e.snapshotFilter)
+		sec.onDelete = e.confirmDelete(label)
+		return sec
+	}
+	e.wallets = mk("Wallets",
+		"Cardano address (addr1... or stake1...)",
+		setup.ValidateWalletAddr)
+	e.dreps = mk("DReps",
+		"DRep ID (drep1... or hex)",
+		setup.ValidateDRepID)
+	e.pools = mk("Pools",
+		"Pool ID (pool1... or hex)",
+		setup.ValidatePoolID)
+	e.assets = mk("Assets",
+		"Asset fingerprint (asset1... — CIP-14)",
+		setup.ValidateAssetFingerprint)
+	e.policies = mk("Policies",
+		"Policy ID (56-character hex)",
+		setup.ValidatePolicyID)
+	e.sections = []*targetSection{
+		e.wallets, e.dreps, e.pools, e.assets, e.policies,
+	}
+
+	e.wallets.setValues(e.working.Filter.Wallets)
+	e.dreps.setValues(e.working.Filter.DReps)
+	e.pools.setValues(e.working.Filter.Pools)
+	e.assets.setValues(e.working.Filter.Assets)
+	e.policies.setValues(e.working.Filter.Policies)
+
+	e.targetsBox = container.NewVBox(
+		e.wallets.canvasObject(),
+		widget.NewSeparator(),
+		e.dreps.canvasObject(),
+		widget.NewSeparator(),
+		e.pools.canvasObject(),
+		widget.NewSeparator(),
+		e.assets.canvasObject(),
+		widget.NewSeparator(),
+		e.policies.canvasObject(),
+	)
+
+	// Hydrate Checked + initial visibility BEFORE wiring OnChanged so
+	// hydration cannot trigger a spurious user-action side effect.
+	// Same pattern as the pref-checks below.
+	e.everythingCheck = widget.NewCheck(
+		"Monitor Everything (ignore per-target lists)", nil,
+	)
+	e.everythingCheck.Checked = e.working.Filter.MonitorEverything
+	if e.working.Filter.MonitorEverything {
+		e.targetsBox.Hide()
+	}
+	e.everythingCheck.OnChanged = func(checked bool) {
+		e.working.Filter.MonitorEverything = checked
+		if checked {
+			e.targetsBox.Hide()
+		} else {
+			e.targetsBox.Show()
+		}
+	}
+}
+
+// buildPrefBox builds one widget.Check per pref in setup.AllNotifyPrefs.
+// Toggling a check flips that pref on the working plan; the engine
+// derives one rule per category per target so flipping a pref
+// enables/disables every rule for that category at once.
+func (e *RulesEditor) buildPrefBox() fyne.CanvasObject {
+	prefs := setup.AllNotifyPrefs()
+	rows := make([]fyne.CanvasObject, 0, 2+len(prefs))
+	rows = append(
+		rows,
+		widget.NewLabelWithStyle(
+			"Notification Preferences",
+			fyne.TextAlignLeading,
+			fyne.TextStyle{Bold: true},
+		),
+		widget.NewLabel(
+			"Each preference controls one category of rule across "+
+				"all configured targets.",
+		),
+	)
+	if e.working.Notify == nil {
+		e.working.Notify = make(setup.NotificationPrefs)
+	}
+	// Backfill missing prefs with the default-on convention used by
+	// wizard step 4 (createChecks), so sparse / upgraded configs do
+	// not silently appear opted-out in the editor and an unconfigured
+	// pref ships through Apply with the same value the wizard would.
+	for _, pref := range prefs {
+		if _, ok := e.working.Notify[pref]; !ok {
+			e.working.Notify[pref] = true
+		}
+	}
+	for _, pref := range prefs {
+		check := widget.NewCheck(pref, nil)
+		// Set the initial state BEFORE wiring OnChanged so the
+		// hydration assignment cannot trigger a working-map write
+		// under any driver that fires OnChanged from SetChecked.
+		check.Checked = e.working.Notify[pref]
+		check.OnChanged = func(checked bool) {
+			e.working.Notify[pref] = checked
+		}
+		e.prefChecks[pref] = check
+		rows = append(rows, check)
+	}
+	return container.NewVBox(rows...)
+}
+
+// snapshotFilter copies the targetSection values back into the working
+// filter after every add/remove so Apply ships an up-to-date plan.
+// When MonitorEverything is on, the per-target lists are nilled so the
+// persisted YAML matches the wizard step3 behaviour and the editor's
+// section rows do not "resurrect" on next open.
+func (e *RulesEditor) snapshotFilter() {
+	if e.working.Filter.MonitorEverything {
+		e.working.Filter.Wallets = nil
+		e.working.Filter.DReps = nil
+		e.working.Filter.Pools = nil
+		e.working.Filter.Assets = nil
+		e.working.Filter.Policies = nil
+		return
+	}
+	e.working.Filter.Wallets = append(
+		[]string(nil), e.wallets.values...,
+	)
+	e.working.Filter.DReps = append(
+		[]string(nil), e.dreps.values...,
+	)
+	e.working.Filter.Pools = append(
+		[]string(nil), e.pools.values...,
+	)
+	e.working.Filter.Assets = append(
+		[]string(nil), e.assets.values...,
+	)
+	e.working.Filter.Policies = append(
+		[]string(nil), e.policies.values...,
+	)
+}
+
+// onApply snapshots the working plan, freezes every mutating input
+// (including Cancel / window-close so the warning dialog's parent
+// cannot vanish), and hands a deep copy to the callback (which runs
+// on a background goroutine — the deep copy keeps RulesFromPlan reads
+// race-free).
+func (e *RulesEditor) onApply() {
+	e.snapshotFilter()
+	e.applying = true
+	e.setInputsEnabled(false)
+	if e.callback != nil {
+		e.callback(e.ctx, setup.ClonePlan(e.working), e)
+	}
+}
+
+// setInputsEnabled toggles every mutating input on the editor (apply
+// button, prefs, everything toggle, section entries + add buttons +
+// per-row trash buttons).
+func (e *RulesEditor) setInputsEnabled(enabled bool) {
+	toggle := func(d fyne.Disableable) {
+		if enabled {
+			d.Enable()
+		} else {
+			d.Disable()
+		}
+	}
+	toggle(e.applyBtn)
+	toggle(e.closeBtn)
+	toggle(e.everythingCheck)
+	for _, c := range e.prefChecks {
+		toggle(c)
+	}
+	for _, sec := range e.sections {
+		sec.setEnabled(enabled)
+	}
+}
+
+// Window returns the editor's top-level window so external callers
+// can parent dialogs on the surface that initiated the work.
+func (e *RulesEditor) Window() fyne.Window {
+	return e.window
+}
+
+// Close cancels the editor context and closes the window. Marks
+// applying=false first so onRulesApply's success path can call Close
+// even when the window is still showing the warning dialog.
+func (e *RulesEditor) Close() {
+	e.applying = false
+	e.cancel()
+	e.window.Close()
+}
+
+// EnableButtons re-enables every input frozen by onApply, restoring
+// the Cancel button + native window-close affordance.
+func (e *RulesEditor) EnableButtons() {
+	e.applying = false
+	e.setInputsEnabled(true)
+}

--- a/tray/wizard/rules_editor_test.go
+++ b/tray/wizard/rules_editor_test.go
@@ -1,0 +1,525 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"context"
+	"testing"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/test"
+	"fyne.io/fyne/v2/widget"
+	"github.com/blinklabs-io/adder/tray/setup"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func samplePlan() setup.SetupPlan {
+	return setup.SetupPlan{
+		Filter: setup.FilterConfig{
+			Wallets: []string{
+				"addr1q9hlrf6lmtgu7mqupwlysw7qcvexmjkmwfynqlfh33dz87xy3y67g60shkajwfsewt2tjs85a3xkpkmcafpwwzpevlcsmwzj82",
+			},
+			DReps: []string{
+				"drep1y2cvruq6syfa4w7uksw9jur9q06lwlc60p9kjcxnxd9ww7gh8gtt0",
+			},
+		},
+		Notify: setup.NotificationPrefs{
+			setup.NotifyPrefIncomingTx:       true,
+			setup.NotifyPrefOutgoingTx:       false,
+			setup.NotifyPrefBlocksMinted:     true,
+			setup.NotifyPrefConnectionIssues: true,
+		},
+		Output: setup.OutputConfig{Config: map[string]string{}},
+	}
+}
+
+func TestSetupClonePlanIsDeep(t *testing.T) {
+	orig := samplePlan()
+	clone := setup.ClonePlan(orig)
+
+	clone.Filter.Wallets = append(clone.Filter.Wallets, "addr1other")
+	clone.Notify[setup.NotifyPrefIncomingTx] = false
+	clone.Output.Config["x"] = "y"
+
+	// Original maps + slices must be untouched.
+	assert.Len(t, orig.Filter.Wallets, 1)
+	assert.True(t, orig.Notify[setup.NotifyPrefIncomingTx])
+	_, ok := orig.Output.Config["x"]
+	assert.False(t, ok)
+}
+
+func TestNewRulesEditorHydratesFromPlan(t *testing.T) {
+	test.NewApp()
+	called := false
+	e := NewRulesEditor(samplePlan(), func(
+		_ context.Context,
+		_ setup.SetupPlan,
+		_ *RulesEditor,
+	) {
+		called = true
+	})
+	require.NotNil(t, e.window)
+	// Target sections hydrated.
+	assert.Equal(t, []string{
+		"addr1q9hlrf6lmtgu7mqupwlysw7qcvexmjkmwfynqlfh33dz87xy3y67g60shkajwfsewt2tjs85a3xkpkmcafpwwzpevlcsmwzj82",
+	}, e.wallets.values)
+	assert.Equal(t,
+		[]string{"drep1y2cvruq6syfa4w7uksw9jur9q06lwlc60p9kjcxnxd9ww7gh8gtt0"},
+		e.dreps.values)
+	assert.Empty(t, e.pools.values)
+	// Pref checkboxes hydrated.
+	assert.True(t, prefCheck(t, e, setup.NotifyPrefIncomingTx).Checked)
+	assert.False(t, prefCheck(t, e, setup.NotifyPrefOutgoingTx).Checked)
+	assert.True(t, prefCheck(t, e, setup.NotifyPrefBlocksMinted).Checked)
+	// MonitorEverything toggle off.
+	assert.False(t, e.everythingCheck.Checked)
+
+	e.onApply()
+	assert.True(t, called)
+
+	e.Close()
+	assert.ErrorIs(t, e.ctx.Err(), context.Canceled)
+}
+
+func TestRulesEditorPrefToggleFlipsWorking(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+
+	// Flip Outgoing from false -> true via the check's OnChanged
+	// (what a user tap invokes).
+	chk := prefCheck(t, e, setup.NotifyPrefOutgoingTx)
+	require.False(t, chk.Checked)
+	chk.OnChanged(true)
+	assert.True(t, e.working.Notify[setup.NotifyPrefOutgoingTx])
+
+	// Same-value call is observationally a no-op (assignment writes
+	// true over true).
+	chk.OnChanged(true)
+	assert.True(t, e.working.Notify[setup.NotifyPrefOutgoingTx])
+}
+
+// prefCheck looks up a pref's check widget with nil + missing-key
+// guards so nilaway can see the access is safe and tests fail loudly
+// if a pref disappears from the editor.
+func prefCheck(t *testing.T, e *RulesEditor, key string) *widget.Check {
+	t.Helper()
+	require.NotNil(t, e)
+	chk, ok := e.prefChecks[key]
+	require.True(t, ok, "missing pref %q", key)
+	require.NotNil(t, chk, "nil check for pref %q", key)
+	return chk
+}
+
+func TestRulesEditorEverythingToggleHidesTargets(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+
+	require.True(t, e.targetsBox.Visible())
+	e.everythingCheck.OnChanged(true)
+	assert.False(t, e.targetsBox.Visible())
+	assert.True(t, e.working.Filter.MonitorEverything)
+
+	e.everythingCheck.OnChanged(false)
+	assert.True(t, e.targetsBox.Visible())
+	assert.False(t, e.working.Filter.MonitorEverything)
+}
+
+// TestRulesEditorHydratesMonitorEverythingWithoutFiringOnChanged guards
+// that opening the editor with MonitorEverything=true hides the
+// targets box at construction time WITHOUT relying on Fyne firing
+// OnChanged from SetChecked — the prefs hydration path documents the
+// same invariant.
+func TestRulesEditorHydratesMonitorEverythingWithoutFiringOnChanged(t *testing.T) {
+	test.NewApp()
+	plan := samplePlan()
+	plan.Filter.MonitorEverything = true
+	e := NewRulesEditor(plan, nil)
+	assert.True(t, e.everythingCheck.Checked)
+	assert.False(t, e.targetsBox.Visible(),
+		"targetsBox must be hidden at hydration when "+
+			"MonitorEverything is true")
+}
+
+func TestRulesEditorAddTargetSnapshotsFilter(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+
+	// Add a pool target via the section's add helper.
+	e.pools.add("pool1ws7gpqkw4wpdj33lf3hcjy9zk5pxr8htnnxkxepe49p5gp3srcg")
+	assert.Contains(t, e.working.Filter.Pools,
+		"pool1ws7gpqkw4wpdj33lf3hcjy9zk5pxr8htnnxkxepe49p5gp3srcg")
+}
+
+func TestRulesEditorOnApplyDisablesButtonAndPassesWorking(t *testing.T) {
+	test.NewApp()
+	var gotPlan setup.SetupPlan
+	e := NewRulesEditor(samplePlan(), func(
+		_ context.Context,
+		plan setup.SetupPlan,
+		_ *RulesEditor,
+	) {
+		gotPlan = plan
+	})
+	// Mutate then apply; gotPlan must reflect the mutation.
+	prefCheck(t, e, setup.NotifyPrefVotesCast).OnChanged(true)
+	e.onApply()
+
+	assert.True(t, e.applyBtn.Disabled())
+	assert.True(t, gotPlan.Notify[setup.NotifyPrefVotesCast])
+
+	e.EnableButtons()
+	assert.False(t, e.applyBtn.Disabled())
+}
+
+// TestRulesEditorOnApplyDeepCopiesNotify asserts the callback receives
+// a plan whose Notify map is independent of the editor's working map,
+// so post-Apply UI mutations cannot race the goroutine's reads. The
+// test sets a key TRUE before Apply then flips it FALSE after — a
+// shared-map regression would let the post-Apply flip propagate into
+// gotPlan, failing the assertion (a weaker test that wrote a key the
+// editor never set would pass under a shared-map regression).
+func TestRulesEditorOnApplyDeepCopiesNotify(t *testing.T) {
+	test.NewApp()
+	var gotPlan setup.SetupPlan
+	e := NewRulesEditor(samplePlan(), func(
+		_ context.Context,
+		plan setup.SetupPlan,
+		_ *RulesEditor,
+	) {
+		gotPlan = plan
+	})
+	// Pre-toggle VotesCast TRUE so onApply ships a plan carrying it.
+	prefCheck(t, e, setup.NotifyPrefVotesCast).OnChanged(true)
+	require.True(t, e.working.Notify[setup.NotifyPrefVotesCast])
+	e.onApply()
+	require.True(t, gotPlan.Notify[setup.NotifyPrefVotesCast],
+		"callback should have received the pre-Apply state")
+	// Flip e.working.Notify[VotesCast] to false AFTER Apply. A shared
+	// map alias would propagate that flip to gotPlan.
+	e.working.Notify[setup.NotifyPrefVotesCast] = false
+	assert.True(t, gotPlan.Notify[setup.NotifyPrefVotesCast],
+		"callback plan must be a deep copy of working — "+
+			"post-Apply flip must not propagate")
+	// Filter slices must also be independent.
+	e.working.Filter.Wallets = append(e.working.Filter.Wallets, "addr1z")
+	assert.NotContains(t, gotPlan.Filter.Wallets, "addr1z")
+}
+
+// TestRulesEditorOnApplyFreezesAllInputs asserts that Apply disables
+// every input that mutates working, so the user cannot mutate state
+// the background goroutine is reading.
+func TestRulesEditorOnApplyFreezesAllInputs(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+	e.onApply()
+	assert.True(t, e.applyBtn.Disabled())
+	assert.True(t, e.everythingCheck.Disabled())
+	for pref, c := range e.prefChecks {
+		assert.True(t, c.Disabled(), "pref %q not frozen", pref)
+	}
+	for _, sec := range []*targetSection{
+		e.wallets, e.dreps, e.pools, e.assets, e.policies,
+	} {
+		assert.True(t, sec.addBtn.Disabled(),
+			"%s add button not frozen", sec.label)
+		assert.True(t, sec.entry.Disabled(),
+			"%s entry not frozen", sec.label)
+		for i, b := range sec.rowBtns {
+			assert.True(t, b.Disabled(),
+				"%s row %d trash button not frozen", sec.label, i)
+		}
+	}
+
+	e.EnableButtons()
+	assert.False(t, e.applyBtn.Disabled())
+	assert.False(t, e.everythingCheck.Disabled())
+	for _, c := range e.prefChecks {
+		assert.False(t, c.Disabled())
+	}
+	for _, sec := range []*targetSection{
+		e.wallets, e.dreps, e.pools, e.assets, e.policies,
+	} {
+		assert.False(t, sec.addBtn.Disabled())
+		assert.False(t, sec.entry.Disabled())
+		for _, b := range sec.rowBtns {
+			assert.False(t, b.Disabled())
+		}
+	}
+}
+
+// TestSnapshotFilterNilsSlicesWhenMonitorEverything asserts that
+// flipping the Monitor Everything toggle and snapshotting drops the
+// per-target lists (parity with wizard step3 Apply) so they do not
+// resurrect on the next editor open.
+func TestSnapshotFilterNilsSlicesWhenMonitorEverything(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+	require.NotEmpty(t, e.wallets.values)
+
+	e.everythingCheck.OnChanged(true)
+	e.snapshotFilter()
+	assert.True(t, e.working.Filter.MonitorEverything)
+	assert.Nil(t, e.working.Filter.Wallets)
+	assert.Nil(t, e.working.Filter.DReps)
+	assert.Nil(t, e.working.Filter.Pools)
+	assert.Nil(t, e.working.Filter.Assets)
+	assert.Nil(t, e.working.Filter.Policies)
+}
+
+func TestRulesEditorOnApplyNilCallbackNoPanic(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+	// Should not panic even with nil callback.
+	e.onApply()
+	assert.True(t, e.applyBtn.Disabled())
+}
+
+func TestShowRulesEditorCreatesWindow(t *testing.T) {
+	test.NewApp()
+	ShowRulesEditor(samplePlan(), nil)
+	assert.NotNil(t, test.Canvas())
+}
+
+// findButton walks a fyne object tree (containers + widget renderers)
+// and returns the first *widget.Button whose visible text matches
+// label. Used to drive dialog confirm/dismiss buttons.
+func findButton(obj fyne.CanvasObject, label string) *widget.Button {
+	if obj == nil {
+		return nil
+	}
+	if b, ok := obj.(*widget.Button); ok && b.Text == label {
+		return b
+	}
+	switch v := obj.(type) {
+	case *fyne.Container:
+		for _, c := range v.Objects {
+			if got := findButton(c, label); got != nil {
+				return got
+			}
+		}
+	case fyne.Widget:
+		r := test.WidgetRenderer(v)
+		if r == nil {
+			return nil
+		}
+		for _, c := range r.Objects() {
+			if got := findButton(c, label); got != nil {
+				return got
+			}
+		}
+	}
+	return nil
+}
+
+func tapOverlayButton(t *testing.T, w fyne.Window, label string) bool {
+	t.Helper()
+	top := w.Canvas().Overlays().Top()
+	if top == nil {
+		return false
+	}
+	btn := findButton(top, label)
+	if btn == nil {
+		return false
+	}
+	btn.OnTapped()
+	return true
+}
+
+// TestRulesEditorDeleteTargetConfirms drives a section's trash button
+// in the editor context (onDelete wraps deletion in a confirm dialog).
+// The confirm dialog must appear; tapping Yes drops the value, tapping
+// No keeps it.
+func TestRulesEditorDeleteTargetConfirms(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+
+	// The wallet section has exactly one row from samplePlan. Its
+	// row container holds a trash button (icon-only).
+	require.Len(t, e.wallets.values, 1)
+	row, ok := e.wallets.list.Objects[0].(*fyne.Container)
+	require.True(t, ok)
+
+	// Find the trash button (the only widget.Button in the row).
+	var trash *widget.Button
+	for _, o := range row.Objects {
+		if b, ok := o.(*widget.Button); ok {
+			trash = b
+			break
+		}
+	}
+	require.NotNil(t, trash, "trash button not found in row")
+
+	// Tap trash: confirm dialog must appear.
+	trash.OnTapped()
+	require.NotNil(t, e.window.Canvas().Overlays().Top(),
+		"confirm dialog did not open")
+
+	// Tap No: value preserved.
+	require.True(t, tapOverlayButton(t, e.window, "No"))
+	assert.Len(t, e.wallets.values, 1)
+
+	// Tap trash again, this time confirm.
+	trash.OnTapped()
+	require.True(t, tapOverlayButton(t, e.window, "Yes"))
+	assert.Empty(t, e.wallets.values)
+	// values and the visible list must stay in sync after a delete.
+	assert.Empty(t, e.wallets.list.Objects,
+		"visible list must shrink with values")
+	e.snapshotFilter()
+	assert.Empty(t, e.working.Filter.Wallets)
+}
+
+// TestTargetSectionAddRejectsDuplicate asserts add() rejects a value
+// already present (and within the same batch), so values stays unique
+// and removeValue's "find first match" loop cannot desync the slice
+// from the visible list.
+func TestTargetSectionAddRejectsDuplicate(t *testing.T) {
+	test.NewApp()
+	sec := newTargetSection("Wallets", "addr",
+		setup.ValidateWalletAddr, nil)
+	sec.add(
+		"addr1q9hlrf6lmtgu7mqupwlysw7qcvexmjkmwfynqlfh33dz87xy3y67g60shkajwfsewt2tjs85a3xkpkmcafpwwzpevlcsmwzj82",
+	)
+	require.Len(t, sec.values, 1)
+
+	// Same value again -> rejected via errLabel, values unchanged.
+	sec.add(
+		"addr1q9hlrf6lmtgu7mqupwlysw7qcvexmjkmwfynqlfh33dz87xy3y67g60shkajwfsewt2tjs85a3xkpkmcafpwwzpevlcsmwzj82",
+	)
+	assert.Len(t, sec.values, 1)
+	assert.True(t, sec.errLabel.Visible())
+	assert.Contains(t, sec.errLabel.Text, "already in")
+
+	// Comma-separated batch with internal duplicate -> all rejected.
+	sec.add(
+		"addr1q8j55h0kfan5dxkj57nu9zkv0w2c8py6gvgct69wxptevh89kxh4rln29df4q2pnfcc4y58pjjrev0qfvxv5j93s5e7sx2g78c," +
+			"addr1q8j55h0kfan5dxkj57nu9zkv0w2c8py6gvgct69wxptevh89kxh4rln29df4q2pnfcc4y58pjjrev0qfvxv5j93s5e7sx2g78c",
+	)
+	assert.Len(t, sec.values, 1)
+}
+
+// TestTargetSectionAddDedupIsCaseInsensitive guards that two hex IDs
+// differing only in case are recognised as the same on-chain identity.
+// PolicyID/PoolID/DRepID/AssetFingerprint round-trip through
+// hex.DecodeString which accepts mixed case, so without case-fold
+// dedup the rules engine would emit duplicate per-target rules for
+// the same hash.
+func TestTargetSectionAddDedupIsCaseInsensitive(t *testing.T) {
+	test.NewApp()
+	sec := newTargetSection("Policies", "56-char hex",
+		setup.ValidatePolicyID, nil)
+	const lower = "0123456789abcdef0123456789abcdef0123456789abcdef01234567"
+	sec.add(lower)
+	require.Len(t, sec.values, 1)
+	upper := "0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01234567"
+	sec.add(upper)
+	assert.Len(t, sec.values, 1,
+		"upper/lower hex must dedup — same on-chain policy")
+	assert.True(t, sec.errLabel.Visible())
+}
+
+// TestTargetSectionSetValuesDedupIsCaseInsensitive guards the same
+// invariant on the hydration path (legacy YAML may have stored
+// case-variant duplicates from a pre-dedup release).
+func TestTargetSectionSetValuesDedupIsCaseInsensitive(t *testing.T) {
+	test.NewApp()
+	sec := newTargetSection("Policies", "56-char hex",
+		setup.ValidatePolicyID, nil)
+	sec.setValues([]string{
+		"0123456789abcdef0123456789abcdef0123456789abcdef01234567",
+		"0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF01234567",
+	})
+	assert.Len(t, sec.values, 1,
+		"setValues silently drops case-variant duplicates")
+	assert.Len(t, sec.rowBtns, 1,
+		"rowBtns must stay in lock-step with values")
+}
+
+// TestTargetSectionNoConfirmWhenOnDeleteNil verifies that the shared
+// section keeps its immediate-delete behaviour when used outside the
+// editor (i.e. onDelete is nil — wizard step 3 path).
+func TestTargetSectionNoConfirmWhenOnDeleteNil(t *testing.T) {
+	test.NewApp()
+	called := 0
+	sec := newTargetSection("Wallets", "addr",
+		setup.ValidateWalletAddr,
+		func() { called++ })
+	sec.setValues([]string{
+		"addr1q9hlrf6lmtgu7mqupwlysw7qcvexmjkmwfynqlfh33dz87xy3y67g60shkajwfsewt2tjs85a3xkpkmcafpwwzpevlcsmwzj82",
+	})
+
+	row, ok := sec.list.Objects[0].(*fyne.Container)
+	require.True(t, ok)
+	var trash *widget.Button
+	for _, o := range row.Objects {
+		if b, ok := o.(*widget.Button); ok {
+			trash = b
+			break
+		}
+	}
+	require.NotNil(t, trash)
+
+	trash.OnTapped()
+	assert.Empty(t, sec.values, "delete must be immediate when no win")
+	assert.Equal(t, 1, called, "onChange must fire after delete")
+}
+
+// TestRulesEditorOnApplyBlocksCloseAndCancel guards that Apply
+// freezes both the Cancel button AND the native window-close
+// affordance so the warning dialog's parent cannot be torn down
+// mid-apply. EnableButtons restores both.
+func TestRulesEditorOnApplyBlocksCloseAndCancel(t *testing.T) {
+	test.NewApp()
+	e := NewRulesEditor(samplePlan(), nil)
+	require.False(t, e.applying)
+	require.False(t, e.closeBtn.Disabled())
+
+	e.onApply()
+	assert.True(t, e.applying)
+	assert.True(t, e.closeBtn.Disabled(),
+		"Cancel must be frozen during apply")
+
+	e.EnableButtons()
+	assert.False(t, e.applying)
+	assert.False(t, e.closeBtn.Disabled())
+}
+
+// TestRulesEditorHydratesMissingPrefsToTrue guards parity with the
+// setup wizard's default-on behavior: a pref absent from the saved
+// plan must be checked in the editor and ship through Apply as true,
+// so sparse / upgraded configs do not silently opt out.
+func TestRulesEditorHydratesMissingPrefsToTrue(t *testing.T) {
+	test.NewApp()
+	plan := samplePlan()
+	// Strip every pref from the plan so all are "missing".
+	plan.Notify = setup.NotificationPrefs{}
+	var gotPlan setup.SetupPlan
+	e := NewRulesEditor(plan, func(
+		_ context.Context, p setup.SetupPlan, _ *RulesEditor,
+	) {
+		gotPlan = p
+	})
+	for _, pref := range setup.AllNotifyPrefs() {
+		chk := prefCheck(t, e, pref)
+		assert.Truef(t, chk.Checked,
+			"missing pref %q must hydrate as on", pref)
+	}
+	e.onApply()
+	for _, pref := range setup.AllNotifyPrefs() {
+		assert.Truef(t, gotPlan.Notify[pref],
+			"missing pref %q must ship through Apply as true", pref)
+	}
+}

--- a/tray/wizard/step3_template.go
+++ b/tray/wizard/step3_template.go
@@ -20,34 +20,13 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
 	"fyne.io/fyne/v2/layout"
-	"fyne.io/fyne/v2/theme"
 	"fyne.io/fyne/v2/widget"
 	"github.com/blinklabs-io/adder/tray/setup"
 )
-
-// targetSection is the editable list of one kind of monitoring target
-// (wallets, DReps, or pools). It owns its entry+Add row, its entries
-// list, and its per-section validation label.
-type targetSection struct {
-	label       string // "Wallets" / "DReps" / "Pools"
-	placeholder string
-	validate    func(string) error // ValidateWalletAddr etc.
-
-	entry    *widget.Entry
-	addBtn   *widget.Button
-	errLabel *widget.Label
-	list     *fyne.Container // VBox of entry rows
-	values   []string
-
-	// onChange is called by the section whenever values change, so the
-	// parent step can re-render the summary label.
-	onChange func()
-}
 
 // templateStep is the rebuilt step 3 of the wizard: an exclusive
 // "Monitor Everything" toggle at the top, then three editable target
@@ -208,136 +187,14 @@ func (s *templateStep) Content() fyne.CanvasObject {
 	)
 }
 
-// newSection wires up one editable target list. The Add button validates
-// the input via `validate`, surfaces the error inline on failure, and
-// appends a labelled row with a trash-icon remove button on success.
+// newSection wires up one editable target list for the templateStep,
+// delegating to the shared newTargetSection (see target_section.go).
 func (s *templateStep) newSection(
 	label, placeholder string,
 	validate func(string) error,
 ) *targetSection {
-	sec := &targetSection{
-		label:       label,
-		placeholder: placeholder,
-		validate:    validate,
-		onChange:    s.refreshSummary,
-	}
-	sec.entry = widget.NewEntry()
-	sec.entry.SetPlaceHolder(placeholder)
-	sec.errLabel = widget.NewLabel("")
-	sec.errLabel.Wrapping = fyne.TextWrapWord
-	sec.errLabel.Hide()
-	sec.list = container.NewVBox()
-	sec.addBtn = widget.NewButtonWithIcon(
-		"Add",
-		theme.ContentAddIcon(),
-		func() { sec.add(sec.entry.Text) },
-	)
-	sec.entry.OnSubmitted = func(string) { sec.add(sec.entry.Text) }
-	return sec
-}
-
-// add validates v (splitting on commas first so pasted CSV produces
-// multiple rows) and appends each piece. All-or-nothing: if any piece
-// fails validation, nothing is added and the input is preserved.
-func (sec *targetSection) add(v string) {
-	v = strings.TrimSpace(v)
-	if v == "" {
-		sec.errLabel.SetText("Please enter a value before adding.")
-		sec.errLabel.Show()
-		return
-	}
-	parts := splitAndTrim(v)
-	if len(parts) == 0 {
-		sec.errLabel.SetText("Please enter a value before adding.")
-		sec.errLabel.Show()
-		return
-	}
-	for _, p := range parts {
-		if err := sec.validate(p); err != nil {
-			sec.errLabel.SetText(err.Error())
-			sec.errLabel.Show()
-			return
-		}
-	}
-	sec.errLabel.Hide()
-	for _, p := range parts {
-		sec.values = append(sec.values, p)
-		sec.list.Add(sec.row(p))
-	}
-	sec.entry.SetText("")
-	if sec.onChange != nil {
-		sec.onChange()
-	}
-}
-
-// splitAndTrim splits s on commas, trims whitespace from each piece, and
-// drops empties. A trailing comma or accidental "addr1a, ,addr1b" never
-// produces an empty entry that would fail validation with a confusing
-// "must not be empty" error.
-func splitAndTrim(s string) []string {
-	var out []string
-	for p := range strings.SplitSeq(s, ",") {
-		if p = strings.TrimSpace(p); p != "" {
-			out = append(out, p)
-		}
-	}
-	return out
-}
-
-// row builds a single entry row: a label with the value plus a trash
-// icon that removes it from sec.values and from the visible list.
-func (sec *targetSection) row(v string) fyne.CanvasObject {
-	lbl := widget.NewLabel(v)
-	lbl.Wrapping = fyne.TextWrapBreak
-	var rowObj *fyne.Container
-	removeBtn := widget.NewButtonWithIcon(
-		"",
-		theme.DeleteIcon(),
-		func() {
-			sec.removeValue(v, rowObj)
-		},
-	)
-	rowObj = container.NewBorder(
-		nil, nil, nil, removeBtn, lbl,
-	)
-	return rowObj
-}
-
-func (sec *targetSection) removeValue(v string, row fyne.CanvasObject) {
-	for i, x := range sec.values {
-		if x == v {
-			sec.values = append(sec.values[:i], sec.values[i+1:]...)
-			break
-		}
-	}
-	sec.list.Remove(row)
-	if sec.onChange != nil {
-		sec.onChange()
-	}
-}
-
-// setValues replaces the section's contents with vs. Used to hydrate
-// from a saved plan when the wizard is reopened.
-func (sec *targetSection) setValues(vs []string) {
-	sec.values = sec.values[:0]
-	sec.list.RemoveAll()
-	for _, v := range vs {
-		sec.values = append(sec.values, v)
-		sec.list.Add(sec.row(v))
-	}
-}
-
-func (sec *targetSection) canvasObject() fyne.CanvasObject {
-	return container.NewVBox(
-		widget.NewLabelWithStyle(
-			sec.label, fyne.TextAlignLeading,
-			fyne.TextStyle{Bold: true},
-		),
-		container.NewBorder(
-			nil, nil, nil, sec.addBtn, sec.entry,
-		),
-		sec.errLabel,
-		sec.list,
+	return newTargetSection(
+		label, placeholder, validate, s.refreshSummary,
 	)
 }
 

--- a/tray/wizard/target_section.go
+++ b/tray/wizard/target_section.go
@@ -1,0 +1,255 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package wizard
+
+import (
+	"strings"
+
+	"fyne.io/fyne/v2"
+	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/theme"
+	"fyne.io/fyne/v2/widget"
+)
+
+// targetSection is the editable list of one kind of monitoring target
+// (wallets, DReps, pools, assets, or policies). Owns its entry+Add
+// row, entries list, and per-section validation label. Consumed by
+// the wizard's templateStep and the standalone RulesEditor; per-
+// surface UX (e.g. confirm-before-delete) is injected via callbacks.
+type targetSection struct {
+	label       string // "Wallets" / "DReps" / "Pools" / ...
+	placeholder string
+	validate    func(string) error // ValidateWalletAddr etc.
+
+	entry    *widget.Entry
+	addBtn   *widget.Button
+	errLabel *widget.Label
+	list     *fyne.Container // VBox of entry rows
+	values   []string
+	rowBtns  []*widget.Button // trash buttons parallel to values
+
+	// onChange is invoked after every add/remove so the parent surface
+	// can update derived UI (summary line, rule list rebuild).
+	onChange func()
+
+	// onDelete, when non-nil, wraps every row's trash-button activation.
+	// The wrapper receives the row's value and a doDelete continuation
+	// it must invoke to actually remove the row. Consumers that want a
+	// confirm dialog implement that here; the default (nil) behaves as
+	// immediate delete.
+	onDelete func(v string, doDelete func())
+}
+
+// newTargetSection wires up one editable target list. The Add button
+// validates the input via `validate`, surfaces the error inline on
+// failure, and appends a labelled row with a trash-icon remove button
+// on success. onChange is called after every successful add or remove.
+func newTargetSection(
+	label, placeholder string,
+	validate func(string) error,
+	onChange func(),
+) *targetSection {
+	sec := &targetSection{
+		label:       label,
+		placeholder: placeholder,
+		validate:    validate,
+		onChange:    onChange,
+	}
+	sec.entry = widget.NewEntry()
+	sec.entry.SetPlaceHolder(placeholder)
+	sec.errLabel = widget.NewLabel("")
+	sec.errLabel.Wrapping = fyne.TextWrapWord
+	sec.errLabel.Hide()
+	sec.list = container.NewVBox()
+	sec.addBtn = widget.NewButtonWithIcon(
+		"Add",
+		theme.ContentAddIcon(),
+		func() { sec.add(sec.entry.Text) },
+	)
+	sec.entry.OnSubmitted = func(string) { sec.add(sec.entry.Text) }
+	return sec
+}
+
+// add validates v (splitting on commas first so pasted CSV produces
+// multiple rows) and appends each piece. All-or-nothing: if any piece
+// fails validation, nothing is added and the input is preserved.
+// Duplicates (against existing values OR within the same batch) are
+// rejected as a single error so values stays unique and removeValue's
+// "find first match" loop cannot desync the values slice from the
+// visible list.
+func (sec *targetSection) add(v string) {
+	v = strings.TrimSpace(v)
+	if v == "" {
+		sec.errLabel.SetText("Please enter a value before adding.")
+		sec.errLabel.Show()
+		return
+	}
+	parts := splitAndTrim(v)
+	if len(parts) == 0 {
+		sec.errLabel.SetText("Please enter a value before adding.")
+		sec.errLabel.Show()
+		return
+	}
+	for _, p := range parts {
+		if err := sec.validate(p); err != nil {
+			sec.errLabel.SetText(err.Error())
+			sec.errLabel.Show()
+			return
+		}
+	}
+	// Dedup case-insensitively: hex identifiers (drep/pool/policy/
+	// asset) round-trip through hex.DecodeString which accepts mixed
+	// case, so "ABCDEF" and "abcdef" name the same on-chain entity
+	// and must not both land in the rules engine. Bech32 entries are
+	// spec-mandated lowercase, so case-folding is a no-op for them.
+	existing := make(map[string]struct{}, len(sec.values)+len(parts))
+	for _, x := range sec.values {
+		existing[strings.ToLower(x)] = struct{}{}
+	}
+	for _, p := range parts {
+		k := strings.ToLower(p)
+		if _, dup := existing[k]; dup {
+			sec.errLabel.SetText(
+				"\"" + p + "\" is already in the " + sec.label +
+					" list.")
+			sec.errLabel.Show()
+			return
+		}
+		existing[k] = struct{}{}
+	}
+	sec.errLabel.Hide()
+	for _, p := range parts {
+		sec.appendRow(p)
+	}
+	sec.entry.SetText("")
+	if sec.onChange != nil {
+		sec.onChange()
+	}
+}
+
+// appendRow grows values + rowBtns + list as a single unit so the
+// parallel slices and the visible container never drift.
+func (sec *targetSection) appendRow(v string) {
+	rowObj, btn := sec.row(v)
+	sec.values = append(sec.values, v)
+	sec.rowBtns = append(sec.rowBtns, btn)
+	sec.list.Add(rowObj)
+}
+
+// splitAndTrim splits s on commas, trims whitespace from each piece,
+// and drops empties. A trailing comma or accidental "addr1a, ,addr1b"
+// never produces an empty entry that would fail validation with a
+// confusing "must not be empty" error.
+func splitAndTrim(s string) []string {
+	var out []string
+	for p := range strings.SplitSeq(s, ",") {
+		if p = strings.TrimSpace(p); p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// row builds a single entry row and returns it together with its trash
+// button so callers (appendRow / setValues) can index the button into
+// rowBtns. Trash activation runs through onDelete when set (wrapper
+// may show a confirm dialog) or removes immediately when nil.
+func (sec *targetSection) row(v string) (fyne.CanvasObject, *widget.Button) {
+	lbl := widget.NewLabel(v)
+	lbl.Wrapping = fyne.TextWrapBreak
+	var rowObj *fyne.Container
+	removeBtn := widget.NewButtonWithIcon(
+		"",
+		theme.DeleteIcon(),
+		func() {
+			doDelete := func() { sec.removeValue(v, rowObj) }
+			if sec.onDelete != nil {
+				sec.onDelete(v, doDelete)
+				return
+			}
+			doDelete()
+		},
+	)
+	rowObj = container.NewBorder(
+		nil, nil, nil, removeBtn, lbl,
+	)
+	return rowObj, removeBtn
+}
+
+func (sec *targetSection) removeValue(v string, row fyne.CanvasObject) {
+	for i, x := range sec.values {
+		if x == v {
+			sec.values = append(sec.values[:i], sec.values[i+1:]...)
+			sec.rowBtns = append(sec.rowBtns[:i], sec.rowBtns[i+1:]...)
+			break
+		}
+	}
+	sec.list.Remove(row)
+	if sec.onChange != nil {
+		sec.onChange()
+	}
+}
+
+// setValues replaces the section's contents with vs, dropping
+// case-insensitive duplicates to match add()'s uniqueness invariant.
+func (sec *targetSection) setValues(vs []string) {
+	sec.values = sec.values[:0]
+	sec.rowBtns = sec.rowBtns[:0]
+	sec.list.RemoveAll()
+	// Case-insensitive dedup, matching add()'s invariant.
+	seen := make(map[string]struct{}, len(vs))
+	for _, v := range vs {
+		k := strings.ToLower(v)
+		if _, dup := seen[k]; dup {
+			continue
+		}
+		seen[k] = struct{}{}
+		sec.appendRow(v)
+	}
+}
+
+// setEnabled toggles every input the user can interact with on this
+// section — the entry, the Add button, AND every per-row trash button.
+// Centralises the freeze/thaw policy so a new dynamic widget added to
+// a row is one place to track instead of two.
+func (sec *targetSection) setEnabled(enabled bool) {
+	if enabled {
+		sec.entry.Enable()
+		sec.addBtn.Enable()
+		for _, b := range sec.rowBtns {
+			b.Enable()
+		}
+		return
+	}
+	sec.entry.Disable()
+	sec.addBtn.Disable()
+	for _, b := range sec.rowBtns {
+		b.Disable()
+	}
+}
+
+func (sec *targetSection) canvasObject() fyne.CanvasObject {
+	return container.NewVBox(
+		widget.NewLabelWithStyle(
+			sec.label, fyne.TextAlignLeading,
+			fyne.TextStyle{Bold: true},
+		),
+		container.NewBorder(
+			nil, nil, nil, sec.addBtn, sec.entry,
+		),
+		sec.errLabel,
+		sec.list,
+	)
+}

--- a/tray/wizard/wizard.go
+++ b/tray/wizard/wizard.go
@@ -136,6 +136,12 @@ func (w *WizardController) Close() {
 	w.window.Close()
 }
 
+// Window returns the wizard's top-level window so external callers
+// can parent dialogs on the surface that initiated the work.
+func (w *WizardController) Window() fyne.Window {
+	return w.window
+}
+
 // EnableButtons re-enables navigation buttons if a background task fails.
 func (w *WizardController) EnableButtons() {
 	w.nextBtn.Enable()


### PR DESCRIPTION
Standalone Fyne window opened from a new "Notification Rules..." tray menu item with five target sections, MonitorEverything toggle, per-category preference checkboxes, and per-row delete confirmation. Section primitives moved from step3_template.go into a shared target_section.go with case-insensitive duplicate rejection (hex IDs round-trip through hex.DecodeString which accepts mixed case); per-surface UX (confirm-before-delete vs immediate) is injected via an onDelete callback so the shared widget stays single-purpose.

tray/app.go grows a shared applyPlan helper for onWizardFinish + onRulesApply. SetupRunner.Apply returns the persisted TrayConfig on ApplyResult so applyPlan refreshes a.config from the snapshot (no disk round-trip) and SetRateLimit derives from one source. Reconnect failure and ctx cancellation during the post-save wait are now soft (config IS persisted), surfaced via ApplyResult.ReconnectErr as a standalone error (no wrap of Binary/Restart, which would duplicate context and falsely claim "service registered" when the binary was missing). On soft errors the source surface stays open with re-enabled inputs via a shared handleSoftErrors helper so the warning dialog (a modal child of that window) has a stable parent and the user can retry. setup.AllNotifyPrefs is the canonical pref ordering, pinned end-to-end by TestAllNotifyPrefsHaveEngineRule (every pref must produce at least one enabled rule in RulesFromPlan).

Implements #687

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-app “Notification Rules…” editor from the tray to manage targets and categories with confirm-on-delete and a safe apply. Refactors apply and soft-error handling to hot-reload rules and rate limits without restarting the tray. Implements #687.

- **New Features**
  - New tray item opens a standalone rules editor with five target sections and a “Monitor Everything” toggle.
  - Per-category checkboxes from `setup.AllNotifyPrefs`; CSV paste; case-insensitive dedup for hex IDs; missing prefs default to on.
  - Apply persists config, hot-reloads rules and rate limit from the saved snapshot, then closes the editor and posts a tray notification.
  - Soft warnings keep the window open with inputs re-enabled; per-row deletes confirm.

- **Refactors**
  - Extracted shared `targetSection` (`tray/wizard/target_section.go`) with injectable `onDelete` and full freeze/thaw control.
  - Added `applyPlan` and centralized soft-error handling (`handleSoftErrors`, `resolveDialogParent`) used by wizard and editor.
  - `SetupRunner.Apply` returns `ApplyResult.TrayConfig` and a standalone soft `ReconnectErr` (deadline/cancel are soft), no wrapping.
  - Added `setup.ClonePlan` and canonical `setup.AllNotifyPrefs`; tests cover deep copies, exhaustive prefs, and that each pref produces at least one engine rule.

<sup>Written for commit e3fb8784cefefd26d76f5134ca2dea292fda96e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/760?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Notification Rules” editor in the tray menu for updating monitoring targets and notification preferences.
  * Improved setup changes so the app refreshes tray settings and notification rules more seamlessly after applying updates.

* **Bug Fixes**
  * Soft warnings during setup and rules updates now keep the app responsive and preserve the editor state.
  * Reconnecting after a restart now reports failures more cleanly, and canceled operations no longer surface as hard errors.
  * Target lists now handle duplicate entries more reliably and support comma-separated input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->