### PR TITLE
feat(packaging): signed and notarized macOS .pkg installer

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,9 +50,17 @@ jobs:
         include:
           # Set tray: false on any row to quickly disable that platform's
           # GUI tray build while still producing the core adder binary.
+          # macOS .pkg builds inline on a native runner per arch (arm64 on
+          # macos-15, amd64 on macos-15-intel), not a separate download-artifacts
+          # job: adder-tray needs CGO (Fyne) and can't be cross-compiled, so it
+          # must build on its target arch. build-pkg.sh builds + signs + notarizes.
           - runner: macos-15
             os: darwin
             arch: arm64
+            tray: true
+          - runner: macos-15-intel
+            os: darwin
+            arch: amd64
             tray: true
           - runner: ubuntu-latest
             os: freebsd
@@ -165,7 +173,7 @@ jobs:
             make build-tray
           }
       - name: Build binary
-        if: matrix.os != 'windows'
+        if: matrix.os != 'windows' && matrix.os != 'darwin'
         run: |
           GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} make build
           if [ "${{ matrix.tray }}" = "true" ]; then
@@ -232,56 +240,71 @@ jobs:
           Write-Host "Cleaning up certificate chain"
           Remove-Item -Path "codesign-chain.pem" -Force
 
-      # Sign MacOS build
-
-      - name: Create macOS app bundle
-        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'darwin' }}
+      # Build macOS .pkg installer
+      #
+      # On tag pushes: import both Developer ID certs, store notarytool creds,
+      # then run build-pkg.sh which produces a signed + notarized + stapled
+      # .pkg under dist/. On non-tag pushes: run build-pkg.sh unsigned to
+      # validate the packaging path on every push.
+      - name: Build macOS .pkg
+        if: matrix.os == 'darwin'
+        env:
+          IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_INSTALLER_CERTIFICATE: ${{ secrets.APPLE_INSTALLER_CERTIFICATE }}
+          APPLE_INSTALLER_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_INSTALLER_CERTIFICATE_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: |
-          echo "Packaging ${{ env.APPLICATION_NAME }}..."
-          mkdir -p ${{ env.APPLICATION_NAME }}.app/Contents/MacOS
-          mkdir -p ${{ env.APPLICATION_NAME }}.app/Contents/Resources
-          cp ${{ env.APPLICATION_NAME }} ${{ env.APPLICATION_NAME }}.app/Contents/MacOS/${{ env.APPLICATION_NAME }}
-          chmod +x ${{ env.APPLICATION_NAME }}.app/Contents/MacOS/${{ env.APPLICATION_NAME }}
-          cp .github/assets/${{ env.APPLICATION_NAME }}.icns ${{ env.APPLICATION_NAME }}.app/Contents/Resources
-          export RELEASE_TAG="${{ env.RELEASE_TAG }}"
-          CLEAN_VERSION="${RELEASE_TAG#v}"
-          cat <<EOF > ${{ env.APPLICATION_NAME }}.app/Contents/Info.plist
-          <?xml version="1.0" encoding="UTF-8"?>
-          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-          <plist version="1.0">
-          <dict>
-              <key>CFBundleExecutable</key>
-              <string>${{ env.APPLICATION_NAME }}</string>
-              <key>CFBundleIdentifier</key>
-              <string>com.blinklabssoftware.${{ env.APPLICATION_NAME }}</string>
-              <key>CFBundleName</key>
-              <string>${{ env.APPLICATION_NAME }}</string>
-              <key>CFBundleIconFile</key>
-              <string>${{ env.APPLICATION_NAME }}</string>
-              <key>CFBundleVersion</key>
-              <string>${CLEAN_VERSION}</string>
-              <key>CFBundleShortVersionString</key>
-              <string>${CLEAN_VERSION}</string>
-          </dict>
-          </plist>
-          EOF
+          set -euo pipefail
 
-      - name: Sign and notarize macOS binary
-        if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'darwin' }}
-        run: |
-          echo "Decoding and importing Apple certificate..."
-          echo -n "${{ secrets.APPLE_CERTIFICATE }}" | base64 --decode -o apple_certificate.p12
-          security create-keychain -p "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" build.keychain
-          security default-keychain -s build.keychain
-          security set-keychain-settings -lut 21600 build.keychain
-          security unlock-keychain -p "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" build.keychain
-          security import apple_certificate.p12 -k build.keychain -P "${{ secrets.APPLE_CERTIFICATE_PASSWORD }}" -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "${{ secrets.APPLE_KEYCHAIN_PASSWORD }}" build.keychain
-          /usr/bin/codesign --force -s "Developer ID Application: Blink Labs Software (${{ secrets.APPLE_TEAM_ID }})" --options runtime ${{ env.APPLICATION_NAME }}.app -v
-          xcrun notarytool store-credentials "notarytool-profile" --apple-id "${{ secrets.APPLE_ID }}" --team-id "${{ secrets.APPLE_TEAM_ID }}" --password "${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}"
-          ditto -c -k --keepParent "${{ env.APPLICATION_NAME }}.app" "notarization.zip"
-          xcrun notarytool submit "notarization.zip" --keychain-profile "notarytool-profile" --wait
-          xcrun stapler staple "${{ env.APPLICATION_NAME }}.app"
+          if [ "${IS_RELEASE}" = "true" ]; then
+            echo "::group::Import Apple Developer ID certificates"
+            echo -n "${APPLE_CERTIFICATE}"           | base64 --decode -o apple_app.p12
+            echo -n "${APPLE_INSTALLER_CERTIFICATE}" | base64 --decode -o apple_installer.p12
+
+            security create-keychain  -p "${APPLE_KEYCHAIN_PASSWORD}" build.keychain
+            security default-keychain -s build.keychain
+            security set-keychain-settings -lut 21600 build.keychain
+            security unlock-keychain  -p "${APPLE_KEYCHAIN_PASSWORD}" build.keychain
+
+            # Application cert signs binaries / .app; installer cert signs the pkg.
+            security import apple_app.p12       -k build.keychain -P "${APPLE_CERTIFICATE_PASSWORD}"           -T /usr/bin/codesign
+            security import apple_installer.p12 -k build.keychain -P "${APPLE_INSTALLER_CERTIFICATE_PASSWORD}" -T /usr/bin/productsign
+            security set-key-partition-list -S apple-tool:,apple:,codesign:,productsign: -s -k "${APPLE_KEYCHAIN_PASSWORD}" build.keychain
+
+            rm -f apple_app.p12 apple_installer.p12
+            echo "::endgroup::"
+
+            echo "::group::Store notarytool credentials"
+            xcrun notarytool store-credentials "adder-notary" \
+              --apple-id "${APPLE_ID}" \
+              --team-id  "${APPLE_TEAM_ID}" \
+              --password "${APPLE_APP_SPECIFIC_PASSWORD}"
+            echo "::endgroup::"
+
+            export SIGNING_IDENTITY="Developer ID Application: Blink Labs Software (${APPLE_TEAM_ID})"
+            export INSTALLER_IDENTITY="Developer ID Installer: Blink Labs Software (${APPLE_TEAM_ID})"
+            export TEAM_ID="${APPLE_TEAM_ID}"
+            export NOTARY_PROFILE="adder-notary"
+            export VERSION="${RELEASE_TAG#v}"
+          fi
+
+          export ARCH="${{ matrix.arch }}"
+          ./packaging/macos/build-pkg.sh
+
+          if [ "${IS_RELEASE}" = "true" ]; then
+            echo "::group::Verify pkg with spctl (must be accepted + Notarized Developer ID)"
+            PKG_PATH="dist/${APPLICATION_NAME}-${VERSION}-darwin-${{ matrix.arch }}.pkg"
+            spctl_out=$(spctl -a -vv --type install "${PKG_PATH}" 2>&1)
+            echo "${spctl_out}"
+            echo "${spctl_out}" | grep -q 'accepted'
+            echo "${spctl_out}" | grep -q 'Notarized Developer ID'
+            echo "::endgroup::"
+          fi
 
       - name: Upload release asset (Windows)
         if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows'
@@ -298,22 +321,32 @@ jobs:
           $uploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=$filename"
           Invoke-RestMethod -Uri $uploadUrl -Method Post -Headers $headers -InFile $filename
 
-      - name: Upload release asset
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows'
+      - name: Upload release asset (macOS pkg)
+        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'darwin'
         run: |
-          _filename=${{ env.APPLICATION_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz
-          if [[ "${{ matrix.os }}" != "windows" ]]; then
-            tar czf ${_filename} ${{ env.APPLICATION_NAME }}
-          fi
-          if [[ "${{ matrix.os }}" == "darwin" ]]; then
-            _filename=${{ env.APPLICATION_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.zip
-            zip -r ${_filename} ${{ env.APPLICATION_NAME }}.app
-          fi
-          curl \
+          set -euo pipefail
+          _version="${RELEASE_TAG#v}"
+          _filename="${APPLICATION_NAME}-${_version}-${{ matrix.os }}-${{ matrix.arch }}.pkg"
+          _path="dist/${_filename}"
+          curl --fail --show-error --silent \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/octet-stream" \
-            --data-binary @${_filename} \
-            https://uploads.github.com/repos/${{ github.repository_owner }}/adder/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}
+            --data-binary @"${_path}" \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}"
+
+      - name: Upload release asset
+        if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows' && matrix.os != 'darwin'
+        run: |
+          set -euo pipefail
+          # Build from runtime env (not GitHub expression expansion) so a
+          # crafted tag name can't inject shell; quote all paths.
+          _filename="${APPLICATION_NAME}-${RELEASE_TAG}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
+          tar czf "${_filename}" "${APPLICATION_NAME}"
+          curl --fail --show-error --silent \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Content-Type: application/octet-stream" \
+            --data-binary @"${_filename}" \
+            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}"
 
       - name: Attest binary (Windows)
         if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows'
@@ -321,8 +354,14 @@ jobs:
         with:
           subject-path: '${{ env.APPLICATION_NAME }}.exe'
 
+      - name: Attest pkg (macOS)
+        if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'darwin'
+        uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
+        with:
+          subject-path: 'dist/*.pkg'
+
       - name: Attest binary
-        if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows'
+        if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows' && matrix.os != 'darwin'
         uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0 https://github.com/actions/attest/releases/tag/v4.1.0
         with:
           subject-path: '${{ env.APPLICATION_NAME }}'

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,10 @@
 /adder
 /adder-tray
 
+# macOS installer build output (packaging/macos/build-pkg.sh)
+/dist/
+/build/
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ GO_LDFLAGS=-ldflags "-s -w -X '$(GOMODULE)/internal/version.Version=$(shell git 
 GO_CGO_CFLAGS=$(shell go env CGO_CFLAGS)
 TRAY_CGO_CFLAGS=$(strip $(GO_CGO_CFLAGS) $(if $(filter windows/arm64,$(GOOS)/$(GOARCH)),-DWINBOOL=BOOL,))
 
-.PHONY: build build-tray mod-tidy clean test bundle-macos
+.PHONY: build build-tray mod-tidy clean test bundle-macos pkg-macos pkg-macos-adhoc
 
 # Alias for building program binary
 build: $(BINARIES)
@@ -24,6 +24,18 @@ build: $(BINARIES)
 # Create a local Adder.app for macOS
 bundle-macos:
 	./bundle-macos.sh
+
+# Build a (signed + notarized when secrets are set) macOS .pkg installer
+# containing both adder and adder-tray inside Adder.app. See
+# packaging/macos/README.md for the env-var contract.
+pkg-macos:
+	./packaging/macos/build-pkg.sh
+
+# Build an ad-hoc-signed macOS .pkg for LOCAL testing (no Developer ID needed).
+# The bundle is ad-hoc signed so the app runs and notifications work; the pkg
+# itself is unsigned (install via `sudo installer -pkg <pkg> -target /`).
+pkg-macos-adhoc:
+	ADHOC=1 ./packaging/macos/build-pkg.sh
 
 mod-tidy:
 	# Needed to fetch new dependencies and add them to go.mod

--- a/packaging/macos/Info.plist
+++ b/packaging/macos/Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        CFBundleExecutable points at the tray GUI: opening Adder.app launches
+        the adder-tray wizard/menu-bar app. The adder CLI rides along in the
+        same MacOS/ directory and is invoked directly by the tray or by users.
+        The __VERSION__ token is substituted by build-pkg.sh at build time.
+    -->
+    <key>CFBundleExecutable</key>
+    <string>adder-tray</string>
+    <key>CFBundleIconFile</key>
+    <string>adder</string>
+    <key>CFBundleIdentifier</key>
+    <string>io.blinklabs.adder</string>
+    <key>CFBundleName</key>
+    <string>Adder</string>
+    <key>CFBundleDisplayName</key>
+    <string>Adder</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>__VERSION__</string>
+    <key>CFBundleVersion</key>
+    <string>__VERSION__</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>11.0</string>
+    <key>LSUIElement</key>
+    <false/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <key>NSUserNotificationAlertStyle</key>
+    <string>alert</string>
+</dict>
+</plist>

--- a/packaging/macos/README.md
+++ b/packaging/macos/README.md
@@ -1,0 +1,245 @@
+# macOS `.pkg` installer
+
+This directory builds a signed and notarized macOS installer package that
+installs **both** the `adder` CLI and the `adder-tray` GUI inside a single
+`Adder.app` bundle.
+
+```
+packaging/macos/
+├── build-pkg.sh        # main build script (build → bundle → pkg → sign → notarize → staple)
+├── distribution.xml    # productbuild distribution definition
+├── Info.plist          # Adder.app metadata (CFBundleIdentifier = io.blinklabs.adder)
+├── README.md           # this file
+└── scripts/
+    ├── preinstall      # quit a running instance before replacing the app
+    └── postinstall     # refresh Launch Services; symlink CLI onto $PATH
+```
+
+## Installed layout
+
+```
+/Applications/Adder.app/Contents/MacOS/adder          # CLI binary
+/Applications/Adder.app/Contents/MacOS/adder-tray     # tray GUI binary
+/Applications/Adder.app/Contents/Info.plist
+/Applications/Adder.app/Contents/Resources/adder.icns
+/usr/local/bin/adder                                  # symlink → ...MacOS/adder
+```
+
+`CFBundleExecutable` is `adder-tray`, so double-clicking `Adder.app` launches the
+tray/wizard GUI. The CLI ships alongside it in the same `MacOS/` directory.
+
+The `postinstall` script creates `/usr/local/bin/adder` as a symlink to the
+in-bundle binary so `adder` is on `$PATH` for shell use, creating
+`/usr/local/bin` if needed. This is **best-effort**: it never fails the install
+(the primary payload is the GUI app in `/Applications`). If `/usr/local` is
+read-only — locked-down or MDM-managed Macs — the symlink is skipped with a
+warning and the CLI remains runnable at
+`/Applications/Adder.app/Contents/MacOS/adder`. The script also refuses to
+overwrite a pre-existing `/usr/local/bin/adder` that isn't already ours (a
+Homebrew formula, another tool, or a user symlink), leaving it untouched.
+
+To uninstall: `sudo rm -rf /Applications/Adder.app /usr/local/bin/adder`.
+
+## What the installer does NOT do
+
+- It does **not** register a LaunchAgent. Service registration is owned by the
+  first-run wizard in `adder-tray`, which knows the user's chosen config. This
+  keeps the installer generic.
+- It does **not** add a Login Item. Start-at-login is offered by the tray's
+  first-run wizard, which asks the user and manages the Login Item.
+
+## Building
+
+```bash
+# Local, unsigned (dev): signing/notarization steps warn and skip.
+./packaging/macos/build-pkg.sh
+
+# Local, ad-hoc signed (dev): app runs AND notifications work (see note below).
+ADHOC=1 ./packaging/macos/build-pkg.sh   # or: make pkg-macos-adhoc
+
+# Signed + notarized (CI / release): set the env vars below.
+SIGNING_IDENTITY="Developer ID Application: Blink Labs Software (<TEAM_ID>)" \
+INSTALLER_IDENTITY="Developer ID Installer: Blink Labs Software (<TEAM_ID>)" \
+TEAM_ID="<TEAM_ID>" \
+NOTARY_PROFILE="adder-notary" \
+VERSION="0.42.0" \
+ARCH="arm64" \
+  ./packaging/macos/build-pkg.sh
+```
+
+The artifact is written to `dist/adder-<version>-darwin-<arch>.pkg`
+(e.g. `dist/adder-0.42.0-darwin-arm64.pkg`).
+
+## Environment variables
+
+| Variable             | Required for | Default                                   | Purpose |
+| -------------------- | ------------ | ----------------------------------------- | ------- |
+| `VERSION`            | optional     | `git describe --tags --always --dirty` (leading `v` stripped) | Installer / app version. For releases set a clean semver (e.g. `0.42.0`); `CFBundleVersion` must be ≤3 dot-separated integers, so the raw `git describe` form (`0.42.0-36-g…`) is only suitable for local dev builds. |
+| `ARCH`               | optional     | `uname -m`                                | Accepts `arm64`/`aarch64` or `amd64`/`x86_64`. Maps to `GOARCH`; the pkg filename uses Go arch naming (`arm64`/`amd64`) to match the CI matrix `arch`. |
+| `ADHOC`              | optional     | _(unset → skip)_                          | `1`/`true` → ad-hoc sign the `.app` when `SIGNING_IDENTITY` is unset. Local/dev only; not notarizable. Needed for working notifications (see below). Ignored when `SIGNING_IDENTITY` is set. |
+| `SIGNING_IDENTITY`   | code signing | _(unset → skip)_                          | **Developer ID Application** identity. Signs the binaries and `.app` with hardened runtime. |
+| `INSTALLER_IDENTITY` | pkg signing  | _(unset → skip)_                          | **Developer ID Installer** identity. Signs the `.pkg` via `productsign`. |
+| `TEAM_ID`            | notarization | _(unset)_                                 | Apple Developer Team ID. Required for the Apple-ID notarization fallback. |
+| `NOTARY_PROFILE`     | notarization | _(unset)_                                 | `notarytool` keychain profile name (preferred auth). |
+| `APPLE_ID`           | notarization | _(unset)_                                 | Apple ID email (fallback auth, used only if `NOTARY_PROFILE` unset). |
+| `APPLE_APP_PASSWORD` | notarization | _(unset)_                                 | App-specific password for `APPLE_ID` (fallback auth). |
+| `ICON_SRC`           | optional     | `.github/assets/Adder.icns`               | Source `.icns` copied to `Resources/adder.icns`. |
+| `DIST_DIR`           | optional     | `<repo>/dist`                             | Where the final `.pkg` is written. |
+| `BUILD_DIR`          | optional     | `<repo>/build/macos`                      | Scratch build/staging directory. |
+
+### Skip-when-unset behavior
+
+The script uses `set -euo pipefail` and treats all signing/notary vars as
+optional (`${VAR:-}`):
+
+- **`SIGNING_IDENTITY` unset** → binaries and `.app` are not code-signed (warns).
+- **`INSTALLER_IDENTITY` unset** → the unsigned `.pkg` is copied to the final
+  name and `productsign` is skipped (warns). Notarization is then also skipped.
+- **No notary credentials** (`NOTARY_PROFILE`, or `APPLE_ID` + `APPLE_APP_PASSWORD`
+  + `TEAM_ID`) → notarization and stapling are skipped (warns).
+
+So a plain local run always yields a working **unsigned** pkg, while CI with the
+secrets set yields a **signed + notarized + stapled** pkg.
+
+### Ad-hoc signing and notifications (`ADHOC=1`)
+
+A fully **unsigned** local build installs and launches, but the tray's
+notification permission prompt never appears. macOS notification authorization
+keys off the bundle's code-signing identity: on Apple Silicon the Go linker
+already stamps each binary with an automatic ad-hoc signature, but that does
+**not** bind `Info.plist` or seal `Resources/`, so the bundle reports
+`Identifier=a.out` and the notification center refuses to prompt.
+
+`ADHOC=1` runs `codesign --force --sign -` on the binaries **and the bundle**
+(inside-out), which binds `Info.plist` and gives the app its real
+`io.blinklabs.adder` identifier. That is enough for first-run notification
+authorization to fire. The `.pkg` itself stays unsigned (ad-hoc cannot satisfy
+`productsign`/notarization), so install it via `sudo installer -pkg <pkg>
+-target /` and expect `spctl --type install` to reject it — that "accepted"
+verdict only comes from the CI signed + notarized build. `ADHOC` is ignored when
+`SIGNING_IDENTITY` is set (the real Developer ID signature supersedes it).
+
+## Required credentials / secrets
+
+To produce a release artifact you need an Apple Developer account with:
+
+1. A **Developer ID Application** certificate (signs binaries / `.app`).
+2. A **Developer ID Installer** certificate (signs the `.pkg`).
+3. Notarization credentials, either:
+   - a `notarytool` keychain profile, or
+   - an Apple ID + app-specific password + Team ID.
+
+Both certificates must be importable into the keychain on the build host.
+
+### Setting up the notary keychain profile (preferred)
+
+```bash
+xcrun notarytool store-credentials "adder-notary" \
+    --apple-id "you@example.com" \
+    --team-id "<TEAM_ID>" \
+    --password "app-specific-password"
+```
+
+Then pass `NOTARY_PROFILE=adder-notary`.
+
+## Toolchain commands used
+
+The script invokes the standard Xcode command-line tools:
+
+```bash
+# Build (mirrors the repo Makefile):
+CGO_ENABLED=0 GOOS=darwin GOARCH=$GOARCH go build -ldflags "..." -tags nodbus -o adder      ./cmd/adder
+CGO_ENABLED=1 GOOS=darwin GOARCH=$GOARCH go build -ldflags "..."              -o adder-tray ./cmd/adder-tray
+
+# Sign binaries + bundle (hardened runtime, secure timestamp):
+codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" Adder.app/Contents/MacOS/adder
+codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" Adder.app/Contents/MacOS/adder-tray
+codesign --force --timestamp --options runtime --sign "$SIGNING_IDENTITY" Adder.app
+codesign --verify --deep --strict --verbose=2 Adder.app
+
+# Component pkg + product archive:
+pkgbuild --root build/macos/root --identifier io.blinklabs.adder --version "$VERSION" \
+         --install-location / --scripts packaging/macos/scripts adder-component.pkg
+productbuild --distribution distribution.xml --package-path build/macos adder-unsigned.pkg
+
+# Sign the pkg (distinct input/output paths required):
+productsign --sign "$INSTALLER_IDENTITY" adder-unsigned.pkg dist/adder-<version>-darwin-<arch>.pkg
+pkgutil --check-signature dist/adder-<version>-darwin-<arch>.pkg
+
+# Notarize (--wait) and staple:
+xcrun notarytool submit dist/adder-<version>-darwin-<arch>.pkg --keychain-profile "$NOTARY_PROFILE" --wait
+#   or: xcrun notarytool submit ... --apple-id "$APPLE_ID" --password "$APPLE_APP_PASSWORD" --team-id "$TEAM_ID" --wait
+xcrun stapler staple   dist/adder-<version>-darwin-<arch>.pkg
+xcrun stapler validate dist/adder-<version>-darwin-<arch>.pkg
+```
+
+## Verifying the release artifact
+
+After a signed + notarized build, Gatekeeper should accept the installer:
+
+```bash
+spctl -a -vv --type install dist/adder-0.42.0-darwin-arm64.pkg
+# => ... source=Notarized Developer ID
+# => ... accepted
+```
+
+## Known / benign: AppleDouble entries in the payload
+
+`pkgutil --payload-files` on the built pkg lists `._*` (AppleDouble) entries
+alongside the real files, e.g. `._adder`, `._Info.plist`. This is normal
+`pkgbuild` behavior — these carry extended attributes into the cpio payload and
+are reconstructed onto the real files at install time; no `._*` files land on
+disk. Apple's own packages contain them.
+
+Relatedly, macOS (Sequoia and later) stamps a kernel-managed
+`com.apple.provenance` extended attribute on Go-built binaries that `xattr -c`
+cannot remove. It is benign and tolerated by notarization. The build strips all
+*removable* xattrs (quarantine, resource forks, Finder info) before signing,
+which are the attributes that actually break `codesign` sealing.
+
+## CI wiring
+
+The release workflow `.github/workflows/publish.yml` runs `build-pkg.sh` from
+the `build-binaries` matrix on a native macOS runner per arch (arm64 on
+`macos-15`, amd64 on `macos-15-intel`) and uploads each signed + notarized `.pkg` as a
+release asset. Building inline on native runners avoids cross-compiling the
+CGO/Fyne `adder-tray`. Each darwin job:
+
+1. Imports both Developer ID certificates into a temporary keychain via
+   `security create-keychain` / `security import` (Application cert under
+   `APPLE_CERTIFICATE`, Installer cert under `APPLE_INSTALLER_CERTIFICATE`).
+2. Stores notarytool credentials with `xcrun notarytool store-credentials`
+   under the profile name `adder-notary`.
+3. Exports `SIGNING_IDENTITY`, `INSTALLER_IDENTITY`, `TEAM_ID`,
+   `NOTARY_PROFILE`, `VERSION`, `ARCH` and runs `./packaging/macos/build-pkg.sh`.
+4. Asserts `spctl -a -vv --type install dist/adder-*.pkg` reports both
+   `accepted` and `source=Notarized Developer ID`; fails the job otherwise.
+5. Uploads `dist/adder-<version>-darwin-arm64.pkg` as a release asset and
+   attests it with `actions/attest`.
+
+### Required GitHub Actions secrets
+
+| Secret                                   | Format                                | Used for                                  |
+| ---------------------------------------- | ------------------------------------- | ----------------------------------------- |
+| `APPLE_CERTIFICATE`                      | base64 of Developer ID Application `.p12` | `codesign` binaries + `.app` |
+| `APPLE_CERTIFICATE_PASSWORD`             | string                                | password for the Application `.p12` |
+| `APPLE_INSTALLER_CERTIFICATE`            | base64 of Developer ID Installer `.p12`   | `productsign` the `.pkg` |
+| `APPLE_INSTALLER_CERTIFICATE_PASSWORD`   | string                                | password for the Installer `.p12` |
+| `APPLE_KEYCHAIN_PASSWORD`                | string                                | password of the temporary CI keychain |
+| `APPLE_ID`                               | email                                 | notarytool auth |
+| `APPLE_APP_SPECIFIC_PASSWORD`            | app-specific password                 | notarytool auth |
+| `APPLE_TEAM_ID`                          | 10-char team ID                       | notarytool auth + identity string |
+
+To export the Installer cert as a `.p12` from the keychain on a Mac that
+already has it installed:
+
+```bash
+security export -k login.keychain -t identities -f pkcs12 \
+    -P "<password>" -o installer.p12 \
+    "Developer ID Installer: Blink Labs Software (<TEAM_ID>)"
+base64 -i installer.p12 | pbcopy   # paste into the GitHub secret
+```
+
+> Note: the `adder-tray` build requires CGO (Fyne). Build on a native macOS
+> runner for the target architecture; cross-compiling CGO needs a matching SDK
+> and toolchain.

--- a/packaging/macos/build-pkg.sh
+++ b/packaging/macos/build-pkg.sh
@@ -1,0 +1,354 @@
+#!/bin/bash
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# build-pkg.sh - build a (optionally signed and notarized) macOS .pkg installer
+# containing both the `adder` CLI and the `adder-tray` GUI, packaged inside an
+# Adder.app bundle installed to /Applications.
+#
+# The script is fully parameterized via environment variables. Signing,
+# notarization, and stapling are SKIPPED with a clear warning when the relevant
+# credentials are not provided, so it produces an UNSIGNED pkg locally and a
+# signed + notarized pkg in CI. See packaging/macos/README.md for the full
+# env-var contract and the verification steps.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration (all overridable via environment)
+# ---------------------------------------------------------------------------
+
+# Resolve repository paths relative to this script so it works from any CWD.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Go module path, used for the version ldflags (mirrors the Makefile).
+GOMODULE="$(grep '^module' "${REPO_ROOT}/go.mod" | awk '{ print $2 }')"
+
+# Version string. Defaults to the git tag/description; strips a leading "v".
+if [ -z "${VERSION:-}" ]; then
+    VERSION="$(git -C "${REPO_ROOT}" describe --tags --always --dirty 2>/dev/null || echo "0.0.0")"
+fi
+VERSION="${VERSION#v}"
+
+# Commit hash for the version ldflags.
+COMMIT_HASH="$(git -C "${REPO_ROOT}" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+
+# Target architecture: arm64 (default on Apple Silicon) or amd64/x86_64.
+# PKG_ARCH uses Go's arch naming so the pkg filename matches the CI matrix
+# `arch` verbatim, keeping publish.yml's spctl/upload/attest arch-agnostic.
+ARCH="${ARCH:-$(uname -m)}"
+# HOST_ARCH is the Apple arch name (x86_64/arm64) for the distribution.xml
+# hostArchitectures attribute, so each single-arch pkg advertises only the arch
+# it actually contains (Installer then blocks a wrong-arch install).
+case "${ARCH}" in
+    arm64|aarch64) GOARCH="arm64";  PKG_ARCH="arm64";  HOST_ARCH="arm64" ;;
+    x86_64|amd64)  GOARCH="amd64";  PKG_ARCH="amd64";  HOST_ARCH="x86_64" ;;
+    *) echo "ERROR: unsupported ARCH '${ARCH}' (use arm64 or amd64)" >&2; exit 1 ;;
+esac
+
+# Signing / notarization identities (empty => skip the corresponding step).
+#   SIGNING_IDENTITY    "Developer ID Application: ..."  - signs binaries + .app
+#   INSTALLER_IDENTITY  "Developer ID Installer: ..."    - signs the .pkg
+#   TEAM_ID             Apple Developer Team ID (10 chars)
+#   NOTARY_PROFILE      `notarytool store-credentials` keychain profile name
+# Apple ID fallback (used only when NOTARY_PROFILE is unset):
+#   APPLE_ID            Apple ID email
+#   APPLE_APP_PASSWORD  app-specific password for that Apple ID
+SIGNING_IDENTITY="${SIGNING_IDENTITY:-}"
+INSTALLER_IDENTITY="${INSTALLER_IDENTITY:-}"
+TEAM_ID="${TEAM_ID:-}"
+NOTARY_PROFILE="${NOTARY_PROFILE:-}"
+APPLE_ID="${APPLE_ID:-}"
+APPLE_APP_PASSWORD="${APPLE_APP_PASSWORD:-}"
+
+# Bundle identity constants.
+BUNDLE_ID="io.blinklabs.adder"
+APP_NAME="Adder"
+# Pre-lowercased for artifact filenames (kept as a constant rather than using
+# `${APP_NAME,,}`, which is bash 4+ syntax and breaks on macOS' default bash
+# 3.2 used by `macos-latest` GitHub runners).
+APP_NAME_LC="adder"
+
+# Output / work locations.
+DIST_DIR="${DIST_DIR:-${REPO_ROOT}/dist}"
+BUILD_DIR="${BUILD_DIR:-${REPO_ROOT}/build/macos}"
+PKG_NAME="${APP_NAME_LC}-${VERSION}-darwin-${PKG_ARCH}.pkg"
+FINAL_PKG="${DIST_DIR}/${PKG_NAME}"
+COMPONENT_PKG="${BUILD_DIR}/${APP_NAME_LC}-component.pkg"
+UNSIGNED_PKG="${BUILD_DIR}/${APP_NAME_LC}-unsigned.pkg"
+
+# Icon source (already present in the repo).
+ICON_SRC="${ICON_SRC:-${REPO_ROOT}/.github/assets/Adder.icns}"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+log()  { printf '\033[1;34m==>\033[0m %s\n' "$*"; }
+warn() { printf '\033[1;33mWARNING:\033[0m %s\n' "$*" >&2; }
+die()  { printf '\033[1;31mERROR:\033[0m %s\n' "$*" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# 1. Build both binaries
+# ---------------------------------------------------------------------------
+
+build_binaries() {
+    log "Building binaries (version=${VERSION}, commit=${COMMIT_HASH}, arch=${GOARCH})"
+
+    # Mirror the Makefile's version ldflags pattern exactly.
+    local ldflags="-s -w \
+-X '${GOMODULE}/internal/version.Version=${VERSION}' \
+-X '${GOMODULE}/internal/version.CommitHash=${COMMIT_HASH}'"
+
+    mkdir -p "${BUILD_DIR}/bin"
+
+    # adder CLI: CGO disabled, nodbus build tag (matches Makefile $(BINARIES)).
+    log "Building adder CLI (CGO_ENABLED=0 -tags nodbus)"
+    CGO_ENABLED=0 GOOS=darwin GOARCH="${GOARCH}" \
+        go build -ldflags "${ldflags}" -tags nodbus \
+        -o "${BUILD_DIR}/bin/adder" \
+        "${REPO_ROOT}/cmd/adder"
+
+    # adder-tray GUI: CGO enabled for Fyne (matches Makefile build-tray).
+    # NOTE: cross-compiling CGO requires the matching toolchain/SDK; CI must run
+    # on the target arch (or have a configured cross toolchain).
+    log "Building adder-tray GUI (CGO_ENABLED=1)"
+    CGO_ENABLED=1 GOOS=darwin GOARCH="${GOARCH}" \
+        go build -ldflags "${ldflags}" \
+        -o "${BUILD_DIR}/bin/adder-tray" \
+        "${REPO_ROOT}/cmd/adder-tray"
+}
+
+# ---------------------------------------------------------------------------
+# 2. Assemble the Adder.app bundle
+# ---------------------------------------------------------------------------
+
+assemble_app() {
+    log "Assembling ${APP_NAME}.app bundle"
+
+    local app_root="${BUILD_DIR}/root/Applications/${APP_NAME}.app"
+    local contents="${app_root}/Contents"
+    local macos="${contents}/MacOS"
+    local resources="${contents}/Resources"
+
+    rm -rf "${BUILD_DIR}/root"
+    mkdir -p "${macos}" "${resources}"
+
+    # Both binaries keep their real names inside MacOS/.
+    install -m 0755 "${BUILD_DIR}/bin/adder"      "${macos}/adder"
+    install -m 0755 "${BUILD_DIR}/bin/adder-tray" "${macos}/adder-tray"
+
+    # Icon -> Resources/adder.icns (CFBundleIconFile = "adder"). A missing icon
+    # is fatal for a signed/release build (an iconless bundle ships broken), but
+    # only a warning for local/ad-hoc dev where the asset may be intentionally
+    # absent.
+    if [ -f "${ICON_SRC}" ]; then
+        install -m 0644 "${ICON_SRC}" "${resources}/adder.icns"
+    elif [ -n "${SIGNING_IDENTITY}" ]; then
+        die "Icon not found at ${ICON_SRC}; refusing to build a release bundle without it."
+    else
+        warn "Icon not found at ${ICON_SRC}; bundle will ship without an icon."
+        warn "Provide an .icns at that path (or set ICON_SRC) for a complete app."
+    fi
+
+    # Info.plist with version tokens substituted.
+    sed "s/__VERSION__/${VERSION}/g" \
+        "${SCRIPT_DIR}/Info.plist" > "${contents}/Info.plist"
+
+    # Strip removable extended attributes before signing. Quarantine flags,
+    # resource forks, and Finder info on a Developer-ID-signed bundle break
+    # codesign sealing, so clear them defensively. Note: macOS stamps a
+    # kernel-managed com.apple.provenance xattr on Go-built binaries that
+    # xattr cannot remove; it is benign and tolerated by notarization.
+    xattr -cr "${app_root}" || true
+
+    APP_BUNDLE="${app_root}"
+}
+
+# ---------------------------------------------------------------------------
+# 3. Sign the .app bundle + inner binaries (Developer ID Application)
+# ---------------------------------------------------------------------------
+
+sign_app() {
+    local contents="${APP_BUNDLE}/Contents"
+
+    # Developer ID path: real code signing for distribution (CI / release).
+    if [ -n "${SIGNING_IDENTITY}" ]; then
+        log "Code signing with hardened runtime: ${SIGNING_IDENTITY}"
+
+        # Sign inner Mach-O binaries first, then the bundle (inside-out).
+        codesign --force --timestamp --options runtime \
+            --sign "${SIGNING_IDENTITY}" \
+            "${contents}/MacOS/adder"
+        codesign --force --timestamp --options runtime \
+            --sign "${SIGNING_IDENTITY}" \
+            "${contents}/MacOS/adder-tray"
+
+        codesign --force --timestamp --options runtime \
+            --sign "${SIGNING_IDENTITY}" \
+            "${APP_BUNDLE}"
+
+        log "Verifying code signature"
+        codesign --verify --deep --strict --verbose=2 "${APP_BUNDLE}"
+        return 0
+    fi
+
+    # Ad-hoc path (ADHOC=1): sign the BUNDLE with the null identity ("-").
+    # Unlike the Go linker's per-binary ad-hoc stub, signing the bundle binds
+    # Info.plist so the app gets its real identifier (io.blinklabs.adder, not
+    # "a.out") - macOS keys notification authorization off that, so the
+    # first-run prompt never appears otherwise. Not notarizable; local/dev only.
+    if [ "${ADHOC:-0}" = "1" ] || [ "${ADHOC:-}" = "true" ]; then
+        warn "Ad-hoc signing (codesign -s -): LOCAL/DEV ONLY, not notarizable."
+        # inside-out: binaries first, then the bundle
+        codesign --force --sign - "${contents}/MacOS/adder"
+        codesign --force --sign - "${contents}/MacOS/adder-tray"
+        codesign --force --sign - "${APP_BUNDLE}"
+        log "Verifying ad-hoc signature"
+        codesign --verify --strict --verbose=2 "${APP_BUNDLE}"
+        return 0
+    fi
+
+    warn "SIGNING_IDENTITY unset - SKIPPING code signing of binaries and .app."
+    warn "The resulting pkg will NOT pass notarization or Gatekeeper."
+    warn "For a runnable local build with working notifications, set ADHOC=1."
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# 4. Build component pkg + wrap with productbuild + distribution.xml
+# ---------------------------------------------------------------------------
+
+build_pkg() {
+    log "Building component package (pkgbuild)"
+    mkdir -p "${BUILD_DIR}" "${DIST_DIR}"
+
+    # Generate a component plist with BundleIsRelocatable=false so macOS does
+    # NOT silently retarget the install to any pre-existing Adder.app on disk
+    # (Spotlight-indexed dev builds, prior installs, etc.). Without this the
+    # postinstall script runs against the wrong /Applications path and the
+    # install fails. See `man pkgbuild` ("Component Property List").
+    local component_plist="${BUILD_DIR}/component.plist"
+    pkgbuild --analyze --root "${BUILD_DIR}/root" "${component_plist}" >/dev/null
+    /usr/libexec/PlistBuddy -c "Set :0:BundleIsRelocatable false" "${component_plist}"
+
+    pkgbuild \
+        --root "${BUILD_DIR}/root" \
+        --component-plist "${component_plist}" \
+        --identifier "${BUNDLE_ID}" \
+        --version "${VERSION}" \
+        --install-location "/" \
+        --scripts "${SCRIPT_DIR}/scripts" \
+        "${COMPONENT_PKG}"
+
+    log "Building product archive (productbuild)"
+    # Substitute tokens into a working copy of distribution.xml.
+    local dist_xml="${BUILD_DIR}/distribution.xml"
+    sed -e "s/__VERSION__/${VERSION}/g" \
+        -e "s/__HOST_ARCH__/${HOST_ARCH}/g" \
+        -e "s|__COMPONENT_PKG__|$(basename "${COMPONENT_PKG}")|g" \
+        "${SCRIPT_DIR}/distribution.xml" > "${dist_xml}"
+
+    productbuild \
+        --distribution "${dist_xml}" \
+        --package-path "${BUILD_DIR}" \
+        "${UNSIGNED_PKG}"
+}
+
+# ---------------------------------------------------------------------------
+# 5. Sign the pkg (Developer ID Installer) or pass through unsigned
+# ---------------------------------------------------------------------------
+
+sign_pkg() {
+    mkdir -p "${DIST_DIR}"
+    if [ -z "${INSTALLER_IDENTITY}" ]; then
+        warn "INSTALLER_IDENTITY unset - SKIPPING pkg signing (productsign)."
+        warn "Producing an UNSIGNED installer: ${FINAL_PKG}"
+        # productsign cannot sign in place; here we simply move the unsigned pkg.
+        cp -f "${UNSIGNED_PKG}" "${FINAL_PKG}"
+        return 0
+    fi
+
+    log "Signing pkg with Developer ID Installer: ${INSTALLER_IDENTITY}"
+    # productsign requires distinct input and output paths.
+    productsign --sign "${INSTALLER_IDENTITY}" \
+        "${UNSIGNED_PKG}" "${FINAL_PKG}"
+
+    log "Verifying pkg signature"
+    pkgutil --check-signature "${FINAL_PKG}"
+}
+
+# ---------------------------------------------------------------------------
+# 6. Notarize + staple
+# ---------------------------------------------------------------------------
+
+notarize_pkg() {
+    # Notarization only makes sense for a signed pkg.
+    if [ -z "${INSTALLER_IDENTITY}" ]; then
+        warn "Pkg is unsigned - SKIPPING notarization and stapling."
+        return 0
+    fi
+
+    # Build notarytool auth arguments from whichever credential set is present.
+    local -a notary_auth=()
+    if [ -n "${NOTARY_PROFILE}" ]; then
+        notary_auth=(--keychain-profile "${NOTARY_PROFILE}")
+    elif [ -n "${APPLE_ID}" ] && [ -n "${APPLE_APP_PASSWORD}" ] && [ -n "${TEAM_ID}" ]; then
+        notary_auth=(--apple-id "${APPLE_ID}" \
+                     --password "${APPLE_APP_PASSWORD}" \
+                     --team-id "${TEAM_ID}")
+    else
+        warn "No notarization credentials (NOTARY_PROFILE, or APPLE_ID + \
+APPLE_APP_PASSWORD + TEAM_ID) - SKIPPING notarization and stapling."
+        return 0
+    fi
+
+    log "Submitting to Apple notarization service (notarytool, --wait)"
+    xcrun notarytool submit "${FINAL_PKG}" "${notary_auth[@]}" --wait
+
+    log "Stapling notarization ticket"
+    xcrun stapler staple "${FINAL_PKG}"
+
+    log "Validating stapled ticket"
+    xcrun stapler validate "${FINAL_PKG}"
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+    log "Adder macOS installer build"
+    log "  version : ${VERSION}"
+    log "  arch    : ${PKG_ARCH} (GOARCH=${GOARCH})"
+    log "  output  : ${FINAL_PKG}"
+
+    build_binaries
+    assemble_app
+    sign_app
+    build_pkg
+    sign_pkg
+    notarize_pkg
+
+    log "Done: ${FINAL_PKG}"
+    if [ -z "${INSTALLER_IDENTITY}" ]; then
+        warn "This is an UNSIGNED, UN-notarized build (local/dev)."
+        warn "It will be blocked by Gatekeeper on other machines."
+    else
+        log "Verify with: spctl -a -vv --type install \"${FINAL_PKG}\""
+    fi
+}
+
+main "$@"

--- a/packaging/macos/distribution.xml
+++ b/packaging/macos/distribution.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+    productbuild distribution definition for the Adder macOS installer.
+
+    Tokens substituted by build-pkg.sh at build time:
+      __VERSION__       installer/app version (e.g. 0.42.0)
+      __HOST_ARCH__     Apple arch of the payload (arm64 or x86_64)
+      __COMPONENT_PKG__ filename of the component pkg produced by pkgbuild
+                        (e.g. adder-component.pkg)
+-->
+<installer-gui-script minSpecVersion="2">
+    <title>Adder</title>
+    <organization>io.blinklabs</organization>
+
+    <!-- Adder.app is installed to /Applications (a domain the user can write).
+         hostArchitectures is a single arch (__HOST_ARCH__, substituted by
+         build-pkg.sh) because each pkg carries a single-arch payload; this lets
+         Installer block a wrong-arch install. -->
+    <options customize="never" require-scripts="false" rootVolumeOnly="true" hostArchitectures="__HOST_ARCH__"/>
+
+    <!-- Require macOS 11 (Big Sur) or later. -->
+    <volume-check>
+        <allowed-os-versions>
+            <os-version min="11.0"/>
+        </allowed-os-versions>
+    </volume-check>
+
+    <choices-outline>
+        <line choice="default">
+            <line choice="io.blinklabs.adder"/>
+        </line>
+    </choices-outline>
+
+    <choice id="default"/>
+    <choice id="io.blinklabs.adder" visible="false" title="Adder" description="Adder CLI and tray application">
+        <pkg-ref id="io.blinklabs.adder"/>
+    </choice>
+
+    <pkg-ref id="io.blinklabs.adder" version="__VERSION__" onConclusion="none">__COMPONENT_PKG__</pkg-ref>
+</installer-gui-script>

--- a/packaging/macos/scripts/postinstall
+++ b/packaging/macos/scripts/postinstall
@@ -1,0 +1,63 @@
+#!/bin/bash
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# postinstall - runs after the Adder.app payload is laid down.
+#
+# Intentionally generic: this script does NOT register a LaunchAgent. Service
+# registration is owned by the first-run wizard inside adder-tray, which knows
+# the user's chosen configuration. The installer only makes the app available.
+
+# -u catches typos; no -e because the CLI symlink below is a best-effort
+# convenience and must never fail the install (the primary payload is the
+# GUI app in /Applications). We exit 0 regardless of symlink outcome.
+set -u
+
+APP_PATH="/Applications/Adder.app"
+CLI_SRC="${APP_PATH}/Contents/MacOS/adder"
+CLI_LINK="/usr/local/bin/adder"
+
+# Refresh Launch Services so Finder/Spotlight/notifications immediately pick up
+# the freshly installed bundle (icon, display name, URL handlers). Safe no-op if
+# lsregister is unavailable. Failure here must not fail the install.
+LSREGISTER="/System/Library/Frameworks/CoreServices.framework/Frameworks/LaunchServices.framework/Support/lsregister"
+if [ -x "${LSREGISTER}" ] && [ -d "${APP_PATH}" ]; then
+    "${LSREGISTER}" -f "${APP_PATH}" >/dev/null 2>&1 || true
+fi
+
+# Best-effort: expose the adder CLI on $PATH via /usr/local/bin. This is a
+# convenience only - if it fails (read-only /usr/local on locked-down/MDM
+# Macs), the CLI is still runnable at ${CLI_SRC}, so we warn and continue
+# rather than fail the whole install.
+#
+# We also refuse to clobber a foreign /usr/local/bin/adder (another tool, a
+# Homebrew formula, a user symlink): only create the link when it's absent or
+# already points at our in-bundle binary.
+if [ -x "${CLI_SRC}" ]; then
+    /bin/mkdir -p /usr/local/bin 2>/dev/null || true
+    if [ ! -e "${CLI_LINK}" ] || \
+       [ "$(readlink "${CLI_LINK}" 2>/dev/null)" = "${CLI_SRC}" ]; then
+        /bin/ln -sf "${CLI_SRC}" "${CLI_LINK}" 2>/dev/null \
+            || echo "postinstall: could not create ${CLI_LINK}; CLI is at ${CLI_SRC}" >&2
+    else
+        echo "postinstall: ${CLI_LINK} exists and is not ours; leaving it untouched" >&2
+    fi
+else
+    echo "postinstall: CLI binary not found at ${CLI_SRC}; skipping symlink" >&2
+fi
+
+# Note: start-at-login is intentionally NOT handled here. The tray's first-run
+# wizard asks the user and manages the Login Item, keeping the installer generic.
+
+exit 0

--- a/packaging/macos/scripts/preinstall
+++ b/packaging/macos/scripts/preinstall
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Copyright 2026 Blink Labs Software
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# preinstall - runs before the Adder.app payload is laid down.
+#
+# This is intentionally minimal and safe: if a previous Adder.app is running
+# we ask it to quit so the installer can replace it cleanly. We never delete
+# user data or configuration here.
+
+set -u
+
+APP_PATH="/Applications/Adder.app"
+
+# Best-effort: ask a running tray instance to quit so files aren't busy.
+# Failures are non-fatal (the app may not be running).
+if [ -d "${APP_PATH}" ]; then
+    /usr/bin/osascript -e 'tell application "Adder" to quit' >/dev/null 2>&1 || true
+    # pkill -f matches the pattern as a regex; escape "." so the literal path
+    # can't wildcard-match an unrelated process (this runs as root).
+    _tray_pat="${APP_PATH}/Contents/MacOS/adder-tray"
+    /usr/bin/pkill -f "${_tray_pat//./\\.}" >/dev/null 2>&1 || true
+fi
+
+exit 0


### PR DESCRIPTION
Assemble the adder CLI and adder-tray GUI into an Adder.app bundle and build a .pkg via pkgbuild/productbuild. When Developer ID credentials are set the pkg is signed, notarized, and stapled; otherwise those steps skip with a warning. ADHOC=1 ad-hoc signs the bundle for local dev so the notification prompt works. Wired into the darwin release job in publish.yml (unsigned on push, signed on tags, spctl-gated).

Resolves #688

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a signed and notarized macOS `.pkg` that installs `Adder.app` bundling `adder` and `adder-tray`. Wired into releases for Apple Silicon and Intel; Gatekeeper‑accepted. Fulfills #688.

- **New Features**
  - `packaging/macos/build-pkg.sh` builds `Adder.app` and a `.pkg` via `pkgbuild`/`productbuild`, using `packaging/macos/Info.plist` and `distribution.xml` with version/arch tokens; enforces macOS ≥11, sets `hostArchitectures` per build, and `BundleIsRelocatable=false`.
  - Signing/notarization: codesigns binaries and `.app` with a Developer ID Application identity, signs the pkg with a Developer ID Installer identity, then notarizes and staples via `notarytool` (profile or Apple ID fallback). `ADHOC=1` ad‑hoc signs the app for local dev (pkg remains unsigned).
  - Installer scripts: `preinstall` quits a running app; `postinstall` refreshes Launch Services and adds a best‑effort `/usr/local/bin/adder` symlink without clobbering other tools.
  - CI: native `macos-15` (arm64) and `macos-15-intel` (amd64) build, sign, notarize, verify with `spctl` (“accepted” + “Notarized Developer ID”), upload the pkg, and attest it. Makefile adds `pkg-macos`/`pkg-macos-adhoc`; `.gitignore` ignores `/dist` and `/build`; docs in `packaging/macos/README.md`.

<sup>Written for commit a2410f57ea7af843a3853fb9dca41538ac07cc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new macOS installer package for easier installation.
  * Installer now includes both the desktop app and command-line tool together.

* **Bug Fixes**
  * Improved macOS install/uninstall behavior by handling existing app instances more smoothly.
  * Added safer post-install setup so command-line access is configured when available.

* **Documentation**
  * Added macOS packaging and install instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->