### PR TITLE
fix(ci): iterate manifest tags via env var to avoid newline syntax error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -606,8 +606,12 @@ jobs:
             type=semver,pattern={{version}}
       - name: manifest-create
         shell: bash
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          for t in ${{ steps.meta.outputs.tags }}; do
+          # Split multi-line TAGS on IFS at runtime; avoids a newline in the script.
+          # shellcheck disable=SC2086
+          for t in ${TAGS}; do
             # Extract the underlying manifests from each manifests list and create a new single manifest list.
             # Word-splitting of the two command substitutions below is intentional:
             # each digest line becomes a separate argument to `docker manifest create`.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix manifest creation in the publish workflow by iterating over tags via the `TAGS` env var. This avoids newline parsing issues from `${{ steps.meta.outputs.tags }}` and ensures multi-line tags are split at runtime.

<sup>Written for commit 0ef70257a1e31eefbaa90d9b594928fdfa75a7c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

