### PR TITLE
ci(publish): disable adder-tray on freebsd

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,11 +65,11 @@ jobs:
           - runner: ubuntu-latest
             os: freebsd
             arch: amd64
-            tray: true
+            tray: false
           - runner: ubuntu-latest
             os: freebsd
             arch: arm64
-            tray: true
+            tray: false
           - runner: ubuntu-latest
             os: linux
             arch: amd64


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable adder-tray on FreeBSD (amd64 and arm64) in the publish workflow to prevent CI failures and unblock releases. Sets tray to false for FreeBSD matrix entries; other platforms are unchanged.

<sup>Written for commit cd80f779df6ab69c3b1a3c8b89e82714005ac569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

