### PR TITLE
fix(webhook): prevent panics and doneChan data races

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -24,6 +24,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -481,8 +482,7 @@ func handlePing(w http.ResponseWriter, _ *http.Request) {
 func handleHealthcheck(w http.ResponseWriter, _ *http.Request) {
 	healthCheckersMu.RLock()
 	// Make a copy of the slice to avoid races with concurrent RegisterHealthChecker calls
-	checkers := make([]HealthChecker, len(healthCheckers))
-	copy(checkers, healthCheckers)
+	checkers := slices.Clone(healthCheckers)
 	healthCheckersMu.RUnlock()
 
 	// If no health checkers are registered, report as healthy

--- a/output/webhook/options.go
+++ b/output/webhook/options.go
@@ -53,7 +53,10 @@ func WithFormat(format string) WebhookOptionFunc {
 }
 
 // WithRetryConfig specifies the retry configuration for webhook delivery
-func WithRetryConfig(maxRetries int, initialBackoff, maxBackoff time.Duration) WebhookOptionFunc {
+func WithRetryConfig(
+	maxRetries int,
+	initialBackoff, maxBackoff time.Duration,
+) WebhookOptionFunc {
 	return func(o *WebhookOutput) {
 		if maxRetries >= 0 {
 			o.maxRetries = maxRetries

--- a/output/webhook/webhook.go
+++ b/output/webhook/webhook.go
@@ -43,6 +43,7 @@ const (
 )
 
 type WebhookOutput struct {
+	mu             sync.Mutex
 	errorChan      chan error
 	eventChan      chan event.Event
 	doneChan       chan struct{}
@@ -77,9 +78,15 @@ func New(options ...WebhookOptionFunc) *WebhookOutput {
 
 // Start the webhook output
 func (w *WebhookOutput) Start() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if w.eventChan != nil {
+		return nil
+	}
 	// Guard against double-start: wait for existing goroutine to exit
 	if w.doneChan != nil {
 		close(w.doneChan)
+		w.doneChan = nil
 		w.wg.Wait()
 	}
 	w.eventChan = make(chan event.Event, 10)
@@ -90,7 +97,7 @@ func (w *WebhookOutput) Start() error {
 	w.wg.Add(1)
 	// Pass the channels as arguments so the goroutine never reads the
 	// shared struct fields, which Stop() may mutate concurrently.
-	go func(doneChan <-chan struct{}, eventChan <-chan event.Event) {
+	go func(doneChan <-chan struct{}, eventChan <-chan event.Event, errorChan chan<- error) {
 		defer w.wg.Done()
 		for {
 			select {
@@ -105,6 +112,7 @@ func (w *WebhookOutput) Start() error {
 				if payload == nil {
 					w.reportError(
 						logger,
+						errorChan,
 						fmt.Errorf(
 							"received event with nil payload (type %q)",
 							evt.Type,
@@ -118,6 +126,7 @@ func (w *WebhookOutput) Start() error {
 					if context == nil {
 						w.reportError(
 							logger,
+							errorChan,
 							fmt.Errorf(
 								"received %q event with nil context",
 								evt.Type,
@@ -128,6 +137,7 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := payload.(event.BlockEvent); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedPayloadErr(evt.Type, payload),
 						)
 						continue
@@ -135,6 +145,7 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := context.(event.BlockContext); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedContextErr(evt.Type, context),
 						)
 						continue
@@ -143,6 +154,7 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := payload.(event.RollbackEvent); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedPayloadErr(evt.Type, payload),
 						)
 						continue
@@ -151,6 +163,7 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := payload.(event.TransactionEvent); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedPayloadErr(evt.Type, payload),
 						)
 						continue
@@ -158,6 +171,7 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := context.(event.TransactionContext); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedContextErr(evt.Type, context),
 						)
 						continue
@@ -166,6 +180,7 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := payload.(event.GovernanceEvent); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedPayloadErr(evt.Type, payload),
 						)
 						continue
@@ -173,31 +188,36 @@ func (w *WebhookOutput) Start() error {
 					if _, ok := context.(event.GovernanceContext); !ok {
 						w.reportError(
 							logger,
+							errorChan,
 							unexpectedContextErr(evt.Type, context),
 						)
 						continue
 					}
 				default:
-					logger.Error("unknown event type: " + evt.Type)
+					w.reportError(
+						logger,
+						errorChan,
+						fmt.Errorf("received unknown event type %q", evt.Type),
+					)
 					continue
 				}
 				// Send webhook with retry logic and exponential backoff
-				w.sendWebhookWithRetry(&evt)
+				w.sendWebhookWithRetry(doneChan, errorChan, &evt)
 			}
 		}
-	}(w.doneChan, w.eventChan)
+	}(w.doneChan, w.eventChan, w.errorChan)
 	return nil
 }
 
 // reportError surfaces an error on the plugin error channel without
 // blocking. If no consumer is ready, the error is logged instead. This
 // mirrors the non-blocking delivery used by sendWebhookWithRetry.
-func (w *WebhookOutput) reportError(logger plugin.Logger, err error) {
+func (w *WebhookOutput) reportError(logger plugin.Logger, errorChan chan<- error, err error) {
 	logger.Error(err.Error())
 	select {
-	case w.errorChan <- err:
+	case errorChan <- err:
 	default:
-		logger.Warn("could not send error to error channel (full or closed)")
+		logger.Warn("could not send error to error channel (full)")
 	}
 }
 
@@ -465,7 +485,7 @@ func (w *WebhookOutput) SendWebhook(e *event.Event) error {
 }
 
 // sendWebhookWithRetry wraps SendWebhook with retry logic and exponential backoff
-func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
+func (w *WebhookOutput) sendWebhookWithRetry(doneChan <-chan struct{}, errorChan chan<- error, e *event.Event) {
 	logger := logging.GetLogger()
 	var lastErr error
 	backoff := w.initialBackoff
@@ -485,7 +505,7 @@ func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
 			)
 			// Responsive sleep
 			select {
-			case <-w.doneChan:
+			case <-doneChan:
 				return
 			case <-time.After(backoff):
 			}
@@ -529,26 +549,31 @@ func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
 
 	// Send error to error channel for monitoring (non-blocking)
 	select {
-	case w.errorChan <- fmt.Errorf(
+	case errorChan <- fmt.Errorf(
 		"webhook delivery to %s failed after %d retries: %w",
 		w.url,
 		w.maxRetries,
 		lastErr,
 	):
 	default:
-		// Error channel is full or closed, just log
-		logger.Warn("could not send error to error channel (full or closed)")
+		// Error channel is full, just log
+		logger.Warn("could not send error to error channel (full)")
 	}
 }
 
 // Stop the webhook output
 func (w *WebhookOutput) Stop() error {
+	w.mu.Lock()
 	if w.doneChan != nil {
 		close(w.doneChan)
+		w.doneChan = nil
 	}
+	w.mu.Unlock()
+
 	// Wait for goroutine to exit before closing channels
 	w.wg.Wait()
-	w.doneChan = nil
+
+	w.mu.Lock()
 	if w.eventChan != nil {
 		close(w.eventChan)
 		w.eventChan = nil
@@ -557,16 +582,21 @@ func (w *WebhookOutput) Stop() error {
 		close(w.errorChan)
 		w.errorChan = nil
 	}
+	w.mu.Unlock()
 	return nil
 }
 
 // ErrorChan returns the plugin's error channel
 func (w *WebhookOutput) ErrorChan() <-chan error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.errorChan
 }
 
 // InputChan returns the input event channel
 func (w *WebhookOutput) InputChan() chan<- event.Event {
+	w.mu.Lock()
+	defer w.mu.Unlock()
 	return w.eventChan
 }
 

--- a/output/webhook/webhook.go
+++ b/output/webhook/webhook.go
@@ -87,13 +87,10 @@ func (w *WebhookOutput) Start() error {
 	w.doneChan = make(chan struct{})
 	logger := logging.GetLogger()
 	logger.Info("starting webhook server")
-
-	// Capture channels locally to avoid races with Stop()
-	eventChan := w.eventChan
-	doneChan := w.doneChan
-
 	w.wg.Add(1)
-	go func() {
+	// Pass the channels as arguments so the goroutine never reads the
+	// shared struct fields, which Stop() may mutate concurrently.
+	go func(doneChan <-chan struct{}, eventChan <-chan event.Event) {
 		defer w.wg.Done()
 		for {
 			select {
@@ -104,33 +101,124 @@ func (w *WebhookOutput) Start() error {
 				if !ok {
 					return
 				}
-				if evt.Payload == nil {
-					logger.Error("webhook received event with nil payload", "event_type", evt.Type)
+				payload := evt.Payload
+				if payload == nil {
+					w.reportError(
+						logger,
+						fmt.Errorf(
+							"received event with nil payload (type %q)",
+							evt.Type,
+						),
+					)
 					continue
 				}
+				context := evt.Context
 				switch evt.Type {
 				case "input.block":
-					if evt.Context == nil {
-						logger.Error("webhook received block event with nil context")
+					if context == nil {
+						w.reportError(
+							logger,
+							fmt.Errorf(
+								"received %q event with nil context",
+								evt.Type,
+							),
+						)
+						continue
+					}
+					if _, ok := payload.(event.BlockEvent); !ok {
+						w.reportError(
+							logger,
+							unexpectedPayloadErr(evt.Type, payload),
+						)
+						continue
+					}
+					if _, ok := context.(event.BlockContext); !ok {
+						w.reportError(
+							logger,
+							unexpectedContextErr(evt.Type, context),
+						)
+						continue
+					}
+				case "input.rollback":
+					if _, ok := payload.(event.RollbackEvent); !ok {
+						w.reportError(
+							logger,
+							unexpectedPayloadErr(evt.Type, payload),
+						)
 						continue
 					}
 				case "input.transaction":
-					if evt.Context == nil {
-						logger.Error("webhook received transaction event with nil context")
+					if _, ok := payload.(event.TransactionEvent); !ok {
+						w.reportError(
+							logger,
+							unexpectedPayloadErr(evt.Type, payload),
+						)
+						continue
+					}
+					if _, ok := context.(event.TransactionContext); !ok {
+						w.reportError(
+							logger,
+							unexpectedContextErr(evt.Type, context),
+						)
 						continue
 					}
 				case "input.governance":
-					if evt.Context == nil {
-						logger.Error("webhook received governance event with nil context")
+					if _, ok := payload.(event.GovernanceEvent); !ok {
+						w.reportError(
+							logger,
+							unexpectedPayloadErr(evt.Type, payload),
+						)
 						continue
 					}
+					if _, ok := context.(event.GovernanceContext); !ok {
+						w.reportError(
+							logger,
+							unexpectedContextErr(evt.Type, context),
+						)
+						continue
+					}
+				default:
+					logger.Error("unknown event type: " + evt.Type)
+					continue
 				}
 				// Send webhook with retry logic and exponential backoff
 				w.sendWebhookWithRetry(&evt)
 			}
 		}
-	}()
+	}(w.doneChan, w.eventChan)
 	return nil
+}
+
+// reportError surfaces an error on the plugin error channel without
+// blocking. If no consumer is ready, the error is logged instead. This
+// mirrors the non-blocking delivery used by sendWebhookWithRetry.
+func (w *WebhookOutput) reportError(logger plugin.Logger, err error) {
+	logger.Error(err.Error())
+	select {
+	case w.errorChan <- err:
+	default:
+		logger.Warn("could not send error to error channel (full or closed)")
+	}
+}
+
+// unexpectedPayloadErr builds an error describing a payload whose dynamic
+// type does not match the one expected for the given event type.
+func unexpectedPayloadErr(eventType string, payload any) error {
+	return fmt.Errorf(
+		"unexpected payload type %T for event %q",
+		payload,
+		eventType,
+	)
+}
+
+// unexpectedContextErr builds an error describing a context whose dynamic
+// type does not match the one expected for the given event type.
+func unexpectedContextErr(eventType string, context any) error {
+	return fmt.Errorf(
+		"unexpected context type %T for event %q",
+		context,
+		eventType,
+	)
 }
 
 func basicAuth(username, password string) string {
@@ -138,7 +226,7 @@ func basicAuth(username, password string) string {
 	return "Basic " + base64.StdEncoding.EncodeToString([]byte(auth))
 }
 
-func formatWebhook(e *event.Event, format string) []byte {
+func formatWebhook(e *event.Event, format string) ([]byte, error) {
 	var data []byte
 	var err error
 	switch format {
@@ -149,8 +237,14 @@ func formatWebhook(e *event.Event, format string) []byte {
 		var dmefs []*DiscordMessageEmbedField
 		switch e.Type {
 		case "input.block":
-			be := e.Payload.(event.BlockEvent)
-			bc := e.Context.(event.BlockContext)
+			be, ok := e.Payload.(event.BlockEvent)
+			if !ok {
+				return nil, unexpectedPayloadErr(e.Type, e.Payload)
+			}
+			bc, ok := e.Context.(event.BlockContext)
+			if !ok {
+				return nil, unexpectedContextErr(e.Type, e.Context)
+			}
 			dme.Title = "New Cardano Block"
 			dmefs = append(dmefs, &DiscordMessageEmbedField{
 				Name:  "Block Number",
@@ -171,7 +265,10 @@ func formatWebhook(e *event.Event, format string) []byte {
 			baseURL := getBaseURL(bc.NetworkMagic)
 			dme.URL = fmt.Sprintf("%s/block/%s", baseURL, be.BlockHash)
 		case "input.rollback":
-			be := e.Payload.(event.RollbackEvent)
+			be, ok := e.Payload.(event.RollbackEvent)
+			if !ok {
+				return nil, unexpectedPayloadErr(e.Type, e.Payload)
+			}
 			dme.Title = "Cardano Rollback"
 			dmefs = append(dmefs, &DiscordMessageEmbedField{
 				Name:  "Slot Number",
@@ -182,8 +279,14 @@ func formatWebhook(e *event.Event, format string) []byte {
 				Value: be.BlockHash,
 			})
 		case "input.transaction":
-			te := e.Payload.(event.TransactionEvent)
-			tc := e.Context.(event.TransactionContext)
+			te, ok := e.Payload.(event.TransactionEvent)
+			if !ok {
+				return nil, unexpectedPayloadErr(e.Type, e.Payload)
+			}
+			tc, ok := e.Context.(event.TransactionContext)
+			if !ok {
+				return nil, unexpectedContextErr(e.Type, e.Context)
+			}
 			dme.Title = "New Cardano Transaction"
 			dmefs = append(dmefs, &DiscordMessageEmbedField{
 				Name:  "Block Number",
@@ -212,8 +315,14 @@ func formatWebhook(e *event.Event, format string) []byte {
 			baseURL := getBaseURL(tc.NetworkMagic)
 			dme.URL = fmt.Sprintf("%s/tx/%s", baseURL, tc.TransactionHash)
 		case "input.governance":
-			ge := e.Payload.(event.GovernanceEvent)
-			gc := e.Context.(event.GovernanceContext)
+			ge, ok := e.Payload.(event.GovernanceEvent)
+			if !ok {
+				return nil, unexpectedPayloadErr(e.Type, e.Payload)
+			}
+			gc, ok := e.Context.(event.GovernanceContext)
+			if !ok {
+				return nil, unexpectedContextErr(e.Type, e.Context)
+			}
 			dme.Title = "Cardano Governance Event"
 			dmefs = append(dmefs, &DiscordMessageEmbedField{
 				Name:  "Block Number",
@@ -246,15 +355,15 @@ func formatWebhook(e *event.Event, format string) []byte {
 
 		data, err = json.Marshal(dwe)
 		if err != nil {
-			return data
+			return nil, fmt.Errorf("failed to marshal webhook payload: %w", err)
 		}
 	default:
 		data, err = json.Marshal(e)
 		if err != nil {
-			return data
+			return nil, fmt.Errorf("failed to marshal webhook payload: %w", err)
 		}
 	}
-	return data
+	return data, nil
 }
 
 type DiscordWebhookEvent struct {
@@ -280,7 +389,10 @@ func getBaseURL(networkMagic uint32) string {
 func (w *WebhookOutput) SendWebhook(e *event.Event) error {
 	logger := logging.GetLogger()
 	logger.Info(fmt.Sprintf("sending event %s to %s", e.Type, w.url))
-	data := formatWebhook(e, w.format)
+	data, err := formatWebhook(e, w.format)
+	if err != nil {
+		return err
+	}
 	// Setup request
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
@@ -304,16 +416,20 @@ func (w *WebhookOutput) SendWebhook(e *event.Event) error {
 		req.Header.Add("Authorization", basicAuth(w.username, w.password))
 	}
 	// Setup custom transport to allow self-signed SSL
-	defaultTransport := http.DefaultTransport.(*http.Transport)
 	// #nosec G402
 	customTransport := &http.Transport{
-		Proxy:                 defaultTransport.Proxy,
-		DialContext:           defaultTransport.DialContext,
-		MaxIdleConns:          defaultTransport.MaxIdleConns,
-		IdleConnTimeout:       defaultTransport.IdleConnTimeout,
-		ExpectContinueTimeout: defaultTransport.ExpectContinueTimeout,
-		TLSHandshakeTimeout:   defaultTransport.TLSHandshakeTimeout,
-		TLSClientConfig:       &tls.Config{InsecureSkipVerify: w.skipVerify},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: w.skipVerify},
+	}
+	// Copy connection-pool tuning from the default transport when it is the
+	// expected concrete type, rather than asserting unconditionally (which
+	// would panic if DefaultTransport were replaced).
+	if defaultTransport, ok := http.DefaultTransport.(*http.Transport); ok {
+		customTransport.Proxy = defaultTransport.Proxy
+		customTransport.DialContext = defaultTransport.DialContext
+		customTransport.MaxIdleConns = defaultTransport.MaxIdleConns
+		customTransport.IdleConnTimeout = defaultTransport.IdleConnTimeout
+		customTransport.ExpectContinueTimeout = defaultTransport.ExpectContinueTimeout
+		customTransport.TLSHandshakeTimeout = defaultTransport.TLSHandshakeTimeout
 	}
 	client := &http.Client{Transport: customTransport}
 	// Send payload
@@ -354,8 +470,6 @@ func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
 	var lastErr error
 	backoff := w.initialBackoff
 
-	logger.Debug("starting webhook delivery with retry", "url", w.url, "max_retries", w.maxRetries)
-
 	for attempt := 0; attempt <= w.maxRetries; attempt++ {
 		if attempt > 0 {
 			logger.Warn(
@@ -369,7 +483,6 @@ func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
 				"event_type", e.Type,
 				"error", lastErr,
 			)
-
 			// Responsive sleep
 			select {
 			case <-w.doneChan:
@@ -388,9 +501,14 @@ func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
 		if err == nil {
 			if attempt > 0 {
 				logger.Info(
-					fmt.Sprintf("webhook delivery succeeded after %d retries", attempt),
-					"url", w.url,
-					"event_type", e.Type,
+					fmt.Sprintf(
+						"webhook delivery succeeded after %d retries",
+						attempt,
+					),
+					"url",
+					w.url,
+					"event_type",
+					e.Type,
 				)
 			}
 			return
@@ -427,10 +545,10 @@ func (w *WebhookOutput) sendWebhookWithRetry(e *event.Event) {
 func (w *WebhookOutput) Stop() error {
 	if w.doneChan != nil {
 		close(w.doneChan)
-		// Wait for goroutine to exit before clearing field
-		w.wg.Wait()
-		w.doneChan = nil
 	}
+	// Wait for goroutine to exit before closing channels
+	w.wg.Wait()
+	w.doneChan = nil
 	if w.eventChan != nil {
 		close(w.eventChan)
 		w.eventChan = nil

--- a/output/webhook/webhook_test.go
+++ b/output/webhook/webhook_test.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Blink Labs Software
+// Copyright 2025 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,8 +17,11 @@ package webhook
 import (
 	"encoding/json"
 	"io"
+	"math"
 	"net/http"
 	"net/http/httptest"
+	"runtime"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -27,6 +30,271 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+const mainnetNetworkMagic = 764824073
+
+// fastRetry disables backoff sleeping so error paths return promptly.
+func fastRetry() WebhookOptionFunc {
+	return WithRetryConfig(0, time.Millisecond, time.Millisecond)
+}
+
+func blockEvent() event.Event {
+	return event.New(
+		"input.block",
+		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		event.BlockContext{
+			Era:          "Conway",
+			BlockNumber:  100,
+			SlotNumber:   200,
+			NetworkMagic: mainnetNetworkMagic,
+		},
+		event.BlockEvent{
+			BlockHash:  "deadbeef",
+			IssuerVkey: "vkey1",
+		},
+	)
+}
+
+// --- Success-path regression guards --------------------------------------
+
+func TestFormatWebhookAdderSuccess(t *testing.T) {
+	e := blockEvent()
+	data, err := formatWebhook(&e, "adder")
+	require.NoError(t, err)
+	require.NotEmpty(t, data)
+
+	var parsed event.Event
+	require.NoError(t, json.Unmarshal(data, &parsed))
+	assert.Equal(t, "input.block", parsed.Type)
+}
+
+func TestFormatWebhookDiscordSuccess(t *testing.T) {
+	cases := []struct {
+		name string
+		evt  event.Event
+	}{
+		{"block", blockEvent()},
+		{
+			"rollback",
+			event.New("input.rollback", time.Now(), nil,
+				event.RollbackEvent{BlockHash: "abc", SlotNumber: 5}),
+		},
+		{
+			"transaction",
+			event.New("input.transaction", time.Now(),
+				event.TransactionContext{TransactionHash: "tx", BlockNumber: 1},
+				event.TransactionEvent{Fee: 10}),
+		},
+		{
+			"governance",
+			event.New("input.governance", time.Now(),
+				event.GovernanceContext{TransactionHash: "gtx", BlockNumber: 1},
+				event.GovernanceEvent{}),
+		},
+		{
+			"default",
+			event.New("input.other", time.Now(), nil, "raw-payload"),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := formatWebhook(&tc.evt, "discord")
+			require.NoError(t, err)
+			var dwe DiscordWebhookEvent
+			require.NoError(t, json.Unmarshal(data, &dwe))
+		})
+	}
+}
+
+func TestSendWebhookSuccess(t *testing.T) {
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}),
+	)
+	defer srv.Close()
+
+	w := New(WithUrl(srv.URL, false))
+	e := blockEvent()
+	require.NoError(t, w.SendWebhook(&e))
+}
+
+// --- Error-path tests ----------------------------------------------------
+
+func TestFormatWebhookDiscordBadPayloadType(t *testing.T) {
+	// input.block with a payload that is not a BlockEvent
+	e := event.New(
+		"input.block",
+		time.Now(),
+		event.BlockContext{},
+		"not-a-block-event",
+	)
+	data, err := formatWebhook(&e, "discord")
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "unexpected payload type")
+}
+
+func TestFormatWebhookDiscordBadContextType(t *testing.T) {
+	// input.block with a valid payload but wrong context type
+	e := event.New(
+		"input.block",
+		time.Now(),
+		"not-a-block-context",
+		event.BlockEvent{BlockHash: "h"},
+	)
+	data, err := formatWebhook(&e, "discord")
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "unexpected context type")
+}
+
+func TestFormatWebhookMarshalError(t *testing.T) {
+	// A float NaN cannot be marshaled to JSON; embed it in the default
+	// (non-discord) path via an unsupported payload value.
+	e := event.New("input.other", time.Now(), nil, math.NaN())
+	data, err := formatWebhook(&e, "adder")
+	require.Error(t, err)
+	assert.Nil(t, data)
+	assert.Contains(t, err.Error(), "failed to marshal")
+}
+
+func TestSendWebhookFormatError(t *testing.T) {
+	// SendWebhook must propagate formatWebhook errors instead of POSTing.
+	e := event.New(
+		"input.block",
+		time.Now(),
+		event.BlockContext{},
+		"not-a-block-event",
+	)
+	w := New(WithFormat("discord"), WithUrl("http://127.0.0.1:0", false))
+	err := w.SendWebhook(&e)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected payload type")
+}
+
+func TestSendWebhookConnectionRefused(t *testing.T) {
+	// Point at a server we immediately close so the POST fails.
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+	)
+	url := srv.URL
+	srv.Close()
+
+	w := New(WithUrl(url, false))
+	e := blockEvent()
+	require.Error(t, w.SendWebhook(&e))
+}
+
+func TestSendWebhookBadURL(t *testing.T) {
+	// A control character in the URL fails request construction.
+	w := New(WithUrl("http://example.com/\x7f", false))
+	e := blockEvent()
+	require.Error(t, w.SendWebhook(&e))
+}
+
+// drainErr starts a reader on the plugin error channel and returns a
+// function that blocks until one error arrives (or times out). The plugin
+// sends errors non-blockingly on an unbuffered channel, so the reader is
+// started (and given a chance to park on the receive) before the caller
+// feeds the input that triggers the error.
+func drainErr(t *testing.T, w *WebhookOutput) func() error {
+	t.Helper()
+	var (
+		mu    sync.Mutex
+		got   error
+		done  = make(chan struct{})
+		ready = make(chan struct{})
+	)
+	go func() {
+		errChan := w.ErrorChan()
+		close(ready)
+		select {
+		case e := <-errChan:
+			mu.Lock()
+			got = e
+			mu.Unlock()
+		case <-time.After(3 * time.Second):
+		}
+		close(done)
+	}()
+	// Wait for the reader goroutine to start and yield so it has parked on
+	// the receive before the triggering event is delivered.
+	<-ready
+	runtime.Gosched()
+	return func() error {
+		<-done
+		mu.Lock()
+		defer mu.Unlock()
+		return got
+	}
+}
+
+func TestStartNilPayloadSurfacesError(t *testing.T) {
+	w := New(fastRetry())
+	require.NoError(t, w.Start())
+	wait := drainErr(t, w)
+	w.InputChan() <- event.New("input.block", time.Now(), event.BlockContext{}, nil)
+	err := wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil payload")
+	require.NoError(t, w.Stop())
+}
+
+func TestStartNilContextSurfacesError(t *testing.T) {
+	w := New(fastRetry())
+	require.NoError(t, w.Start())
+	wait := drainErr(t, w)
+	w.InputChan() <- event.New(
+		"input.block", time.Now(), nil, event.BlockEvent{BlockHash: "h"},
+	)
+	err := wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "nil context")
+	require.NoError(t, w.Stop())
+}
+
+func TestStartBadPayloadTypeSurfacesError(t *testing.T) {
+	w := New(fastRetry())
+	require.NoError(t, w.Start())
+	wait := drainErr(t, w)
+	w.InputChan() <- event.New(
+		"input.transaction", time.Now(), event.TransactionContext{}, "bogus",
+	)
+	err := wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected payload type")
+	require.NoError(t, w.Stop())
+}
+
+func TestStartDeliveryFailureSurfacesError(t *testing.T) {
+	// Valid event but no reachable server -> retries exhaust -> error.
+	srv := httptest.NewServer(
+		http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}),
+	)
+	url := srv.URL
+	srv.Close()
+
+	w := New(WithUrl(url, false), fastRetry())
+	require.NoError(t, w.Start())
+	wait := drainErr(t, w)
+	e := blockEvent()
+	w.InputChan() <- e
+	err := wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "failed after")
+	require.NoError(t, w.Stop())
+}
+
+func TestStartUnknownEventTypeNoError(t *testing.T) {
+	// Unknown types are logged and skipped, not panicked or errored.
+	w := New(fastRetry())
+	require.NoError(t, w.Start())
+	w.InputChan() <- event.New("input.bogus", time.Now(), nil, "x")
+	// Give the goroutine a moment, then ensure Stop is clean.
+	time.Sleep(20 * time.Millisecond)
+	require.NoError(t, w.Stop())
+}
 
 func TestWebhookOutput_Start(t *testing.T) {
 	received := make(chan []byte, 1)

--- a/output/webhook/webhook_test.go
+++ b/output/webhook/webhook_test.go
@@ -286,13 +286,15 @@ func TestStartDeliveryFailureSurfacesError(t *testing.T) {
 	require.NoError(t, w.Stop())
 }
 
-func TestStartUnknownEventTypeNoError(t *testing.T) {
-	// Unknown types are logged and skipped, not panicked or errored.
+func TestStartUnknownEventTypeSurfacesError(t *testing.T) {
+	// Unknown types are now reported as errors.
 	w := New(fastRetry())
 	require.NoError(t, w.Start())
+	wait := drainErr(t, w)
 	w.InputChan() <- event.New("input.bogus", time.Now(), nil, "x")
-	// Give the goroutine a moment, then ensure Stop is clean.
-	time.Sleep(20 * time.Millisecond)
+	err := wait()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unknown event type")
 	require.NoError(t, w.Stop())
 }
 
@@ -423,3 +425,36 @@ func TestWebhookOutput_BasicAuth(t *testing.T) {
 		t.Fatal("timed out waiting for auth")
 	}
 }
+
+func TestWebhookOutput_ShutdownDuringInFlightRequest(t *testing.T) {
+	// 1. Slow server (stalls for 100ms)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(100 * time.Millisecond)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	w := New(
+		WithUrl(srv.URL, false),
+		WithRetryConfig(0, time.Millisecond, time.Millisecond),
+	)
+
+	require.NoError(t, w.Start())
+
+	// 2. Send an event
+	evt := event.Event{
+		Type:    "input.rollback",
+		Payload: event.RollbackEvent{},
+	}
+	w.InputChan() <- evt
+
+	// 3. Wait briefly for worker to pick up the event and enter SendWebhook
+	time.Sleep(10 * time.Millisecond)
+
+	// 4. Stop concurrently while request is in flight
+	require.NoError(t, w.Stop())
+
+	// Sleep slightly to let mock finish and make sure no races or panics happen
+	time.Sleep(150 * time.Millisecond)
+}
+

--- a/pipeline/pipeline_test.go
+++ b/pipeline/pipeline_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
@@ -269,9 +270,7 @@ func (r *restartablePlugin) OutputChan() <-chan event.Event { return r.outputCha
 func (r *restartablePlugin) getReceived() []event.Event {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	result := make([]event.Event, len(r.received))
-	copy(result, r.received)
-	return result
+	return slices.Clone(r.received)
 }
 
 // TestPipelineRestartWithEvents tests the full start -> process events -> stop -> start -> process events -> stop cycle

--- a/tray/app.go
+++ b/tray/app.go
@@ -24,6 +24,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1105,9 +1106,7 @@ func (a *App) addRecentAlert(req notifications.Request) {
 
 		// Keep the latest 10 matching alerts, newest first so the most recent
 		// transaction or chain event is immediately visible at the top.
-		a.recentEvents = append(a.recentEvents, recentAlert{})
-		copy(a.recentEvents[1:], a.recentEvents[:len(a.recentEvents)-1])
-		a.recentEvents[0] = alert
+		a.recentEvents = slices.Insert(a.recentEvents, 0, alert)
 		if len(a.recentEvents) > 10 {
 			a.recentEvents = a.recentEvents[:10]
 		}


### PR DESCRIPTION
Add safe type assertions for all payloads and contexts. Map doneChan nullification to after waitgroup exit in Stop to prevent concurrency races. Apply slices modernizations.

Closes #703

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents webhook panics and channel races by strict event validation, safe formatting/HTTP transport, and mutex-guarded startup/shutdown. Errors, including unknown event types, now flow to the plugin `errorChan` instead of crashing.

- **Bug Fixes**
  - `output/webhook`: Add mutex to guard lifecycle and channel access; pass `doneChan`/`eventChan`/`errorChan` into worker and retry; non-blocking `reportError` surfaces issues; unknown event types reported via `errorChan`.
  - `output/webhook`: `formatWebhook` now returns errors and `SendWebhook` propagates them; guard `http.DefaultTransport` assertion; retry loop respects `doneChan`; `Start` guards double-start; `Stop` closes/nils under lock, waits, then closes channels to avoid races.

- **Refactors**
  - Use `slices.Clone`/`slices.Insert` in `api`, `pipeline`, and `tray`. Expanded tests cover success paths, validation/format errors, connection failures, unknown events, in-flight shutdown, and error-channel delivery.

<sup>Written for commit 897fe6ae1e5e54499e31eeafe8d9299062348c81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook event validation and error reporting for invalid payloads, contexts, formatting, and delivery failures.
  * Strengthened webhook start/stop behavior to prevent concurrency issues and ensure clean shutdowns.
  * Improved handling of webhook transport configuration and unknown event types.
* **Tests**
  * Added coverage for successful webhook delivery, formatting, validation errors, retry failures, connection errors, and shutdown behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->