### PR TITLE
feat(event): create public constants for event types and adopt them e…

### DIFF
--- a/api/api_internal_test.go
+++ b/api/api_internal_test.go
@@ -307,7 +307,7 @@ func TestIntegration_WebSocketThroughMiddleware(t *testing.T) {
 	assert.Equal(t, http.StatusSwitchingProtocols, resp.StatusCode)
 
 	hub.Broadcast(event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 		Payload:   map[string]string{"hash": "abc123"},
 	})
@@ -318,7 +318,7 @@ func TestIntegration_WebSocketThroughMiddleware(t *testing.T) {
 
 	var received event.Event
 	require.NoError(t, json.Unmarshal(msg, &received))
-	assert.Equal(t, "input.block", received.Type)
+	assert.Equal(t, event.TypeBlock, received.Type)
 }
 
 // TestIntegration_SSEThroughMiddleware verifies SSE (which requires
@@ -341,7 +341,7 @@ func TestIntegration_SSEThroughMiddleware(t *testing.T) {
 	assert.Equal(t, "text/event-stream", resp.Header.Get("Content-Type"))
 
 	hub.Broadcast(event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 		Payload:   map[string]string{"hash": "xyz789"},
 	})
@@ -369,7 +369,7 @@ func TestIntegration_SSEThroughMiddleware(t *testing.T) {
 	select {
 	case res := <-ch:
 		require.NoError(t, res.err)
-		assert.Contains(t, res.line, "input.block")
+		assert.Contains(t, res.line, event.TypeBlock)
 	case <-time.After(3 * time.Second):
 		t.Fatal("timed out waiting for SSE data frame")
 	}

--- a/api/api_internal_test.go
+++ b/api/api_internal_test.go
@@ -318,7 +318,7 @@ func TestIntegration_WebSocketThroughMiddleware(t *testing.T) {
 
 	var received event.Event
 	require.NoError(t, json.Unmarshal(msg, &received))
-	assert.Equal(t, event.TypeBlock, received.Type)
+	assert.Equal(t, "input.block", received.Type)
 }
 
 // TestIntegration_SSEThroughMiddleware verifies SSE (which requires

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -55,7 +55,7 @@ func TestEventHub_WebSocketConnectReceive(t *testing.T) {
 
 	// Broadcast an event
 	testEvt := event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 		Payload:   map[string]string{"hash": "abc123"},
 	}
@@ -79,7 +79,7 @@ func TestEventHub_RingBufferReplay(t *testing.T) {
 	// Broadcast some events before any client connects
 	for i := 0; i < 3; i++ {
 		hub.Broadcast(event.Event{
-			Type:      "input.block",
+			Type:      event.TypeBlock,
 			Timestamp: time.Now(),
 			Payload:   map[string]int{"index": i},
 		})
@@ -110,7 +110,7 @@ func TestEventHub_RingBufferReplay(t *testing.T) {
 
 	assert.Len(t, received, 3)
 	for _, evt := range received {
-		assert.Equal(t, "input.block", evt.Type)
+		assert.Equal(t, event.TypeBlock, evt.Type)
 	}
 }
 
@@ -118,7 +118,7 @@ func TestEventHub_ReplayCanBeDisabled(t *testing.T) {
 	hub := api.NewEventHub(5)
 	defer hub.Close()
 	hub.Broadcast(event.Event{
-		Type:      "input.rollback",
+		Type:      event.TypeRollback,
 		Timestamp: time.Now(),
 	})
 
@@ -146,23 +146,23 @@ func TestEventHub_TypeFiltering(t *testing.T) {
 
 	// Connect with type filter
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") +
-		"/events?types=input.block"
+		"/events?types=" + event.TypeBlock
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	require.NoError(t, err)
 	defer conn.Close()
 
 	// Broadcast events of different types
 	hub.Broadcast(event.Event{
-		Type:      "input.transaction",
+		Type:      event.TypeTransaction,
 		Timestamp: time.Now(),
 	})
 	hub.Broadcast(event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 		Payload:   "wanted",
 	})
 	hub.Broadcast(event.Event{
-		Type:      "input.transaction",
+		Type:      event.TypeTransaction,
 		Timestamp: time.Now(),
 	})
 
@@ -174,7 +174,7 @@ func TestEventHub_TypeFiltering(t *testing.T) {
 	var received event.Event
 	err = json.Unmarshal(msg, &received)
 	require.NoError(t, err)
-	assert.Equal(t, "input.block", received.Type)
+	assert.Equal(t, event.TypeBlock, received.Type)
 
 	// Next read should timeout since we filtered out the transaction events
 	conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
@@ -202,7 +202,7 @@ func TestEventHub_MultipleClients(t *testing.T) {
 
 	// Broadcast an event
 	hub.Broadcast(event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 	})
 
@@ -215,7 +215,7 @@ func TestEventHub_MultipleClients(t *testing.T) {
 		var received event.Event
 		err = json.Unmarshal(msg, &received)
 		require.NoError(t, err)
-		assert.Equal(t, "input.block", received.Type)
+		assert.Equal(t, event.TypeBlock, received.Type)
 	}
 }
 
@@ -238,7 +238,7 @@ func TestEventHub_ClientDisconnectCleanup(t *testing.T) {
 
 	// Broadcast should not panic with no clients
 	hub.Broadcast(event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 	})
 }
@@ -252,7 +252,7 @@ func TestEventHub_SSEFallback(t *testing.T) {
 
 	// Pre-broadcast an event so the SSE response has data immediately
 	hub.Broadcast(event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Now(),
 		Payload:   "sse-test",
 	})
@@ -284,7 +284,7 @@ func TestEventHub_SSEFallback(t *testing.T) {
 			var evt event.Event
 			err = json.Unmarshal([]byte(jsonData), &evt)
 			require.NoError(t, err)
-			assert.Equal(t, "input.block", evt.Type)
+			assert.Equal(t, event.TypeBlock, evt.Type)
 			found = true
 			break
 		}
@@ -312,7 +312,7 @@ func TestEventHub_NonBlockingBroadcast(t *testing.T) {
 		defer wg.Done()
 		for i := 0; i < 200; i++ {
 			hub.Broadcast(event.Event{
-				Type:      "input.block",
+				Type:      event.TypeBlock,
 				Timestamp: time.Now(),
 				Payload:   i,
 			})
@@ -349,7 +349,7 @@ func TestEventHub_InputChan(t *testing.T) {
 	// Use InputChan to feed the hub (simulates pipeline observer)
 	ch := hub.InputChan()
 	ch <- event.Event{
-		Type:      "input.transaction",
+		Type:      event.TypeTransaction,
 		Timestamp: time.Now(),
 	}
 
@@ -360,7 +360,7 @@ func TestEventHub_InputChan(t *testing.T) {
 	var received event.Event
 	err = json.Unmarshal(msg, &received)
 	require.NoError(t, err)
-	assert.Equal(t, "input.transaction", received.Type)
+	assert.Equal(t, event.TypeTransaction, received.Type)
 }
 
 func TestEventHub_RingBufferWraparound(t *testing.T) {
@@ -370,7 +370,7 @@ func TestEventHub_RingBufferWraparound(t *testing.T) {
 	// Broadcast 5 events -- ring wraps around
 	for i := 0; i < 5; i++ {
 		hub.Broadcast(event.Event{
-			Type:      "input.block",
+			Type:      event.TypeBlock,
 			Timestamp: time.Now(),
 			Payload:   i,
 		})

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -110,7 +110,7 @@ func TestEventHub_RingBufferReplay(t *testing.T) {
 
 	assert.Len(t, received, 3)
 	for _, evt := range received {
-		assert.Equal(t, event.TypeBlock, evt.Type)
+		assert.Equal(t, "input.block", evt.Type)
 	}
 }
 
@@ -174,7 +174,7 @@ func TestEventHub_TypeFiltering(t *testing.T) {
 	var received event.Event
 	err = json.Unmarshal(msg, &received)
 	require.NoError(t, err)
-	assert.Equal(t, event.TypeBlock, received.Type)
+	assert.Equal(t, "input.block", received.Type)
 
 	// Next read should timeout since we filtered out the transaction events
 	conn.SetReadDeadline(time.Now().Add(200 * time.Millisecond))
@@ -215,7 +215,7 @@ func TestEventHub_MultipleClients(t *testing.T) {
 		var received event.Event
 		err = json.Unmarshal(msg, &received)
 		require.NoError(t, err)
-		assert.Equal(t, event.TypeBlock, received.Type)
+		assert.Equal(t, "input.block", received.Type)
 	}
 }
 
@@ -284,7 +284,7 @@ func TestEventHub_SSEFallback(t *testing.T) {
 			var evt event.Event
 			err = json.Unmarshal([]byte(jsonData), &evt)
 			require.NoError(t, err)
-			assert.Equal(t, event.TypeBlock, evt.Type)
+			assert.Equal(t, "input.block", evt.Type)
 			found = true
 			break
 		}
@@ -360,7 +360,7 @@ func TestEventHub_InputChan(t *testing.T) {
 	var received event.Event
 	err = json.Unmarshal(msg, &received)
 	require.NoError(t, err)
-	assert.Equal(t, event.TypeTransaction, received.Type)
+	assert.Equal(t, "input.transaction", received.Type)
 }
 
 func TestEventHub_RingBufferWraparound(t *testing.T) {

--- a/docs/adder-tray-filtering.md
+++ b/docs/adder-tray-filtering.md
@@ -242,9 +242,9 @@ ChainSync also emits `input.rollback` when the chain rolls back.
 
 The individual DRep certificate event types are:
 
-- `chainsync.drep.registration`;
-- `chainsync.drep.update`;
-- `chainsync.drep.deregistration`.
+- `input.drep-registration`;
+- `input.drep-update`;
+- `input.drep-retirement`.
 
 The same DRep certificate is also represented inside the transaction's
 `input.governance` event. Consumers must avoid producing duplicate alerts from
@@ -310,7 +310,7 @@ The current DRep-related notification coverage is:
 | Stake credential changes away from followed DRep         | Not directly derivable from one event | Requires prior delegation state                              |
 | Followed DRep inactivity or missed vote                  | Not currently derivable               | Requires proposal deadlines and historical state             |
 | DRep voting-power change                                 | Not currently notified                | Requires delegation and stake-state aggregation              |
-| Individual `chainsync.drep.*` event                      | Not consumed directly by tray rules   | Equivalent certificate is handled through `input.governance` |
+| Individual `input.drep-*` event                      | Not consumed directly by tray rules   | Equivalent certificate is handled through `input.governance` |
 
 The governance event also contains SPO and committee activity, but current
 DRep rules intentionally match only the followed DRep for votes and

--- a/event/drep.go
+++ b/event/drep.go
@@ -23,9 +23,9 @@ const (
 )
 
 const (
-	DRepRegistrationEventType   = "chainsync.drep.registration"
-	DRepUpdateEventType         = "chainsync.drep.update"
-	DRepDeregistrationEventType = "chainsync.drep.deregistration"
+	DRepRegistrationEventType   = TypeDRepRegistration
+	DRepUpdateEventType         = TypeDRepUpdate
+	DRepDeregistrationEventType = TypeDRepRetirement
 )
 
 // DRepCertificateEvent represents a single DRep certificate event

--- a/event/event.go
+++ b/event/event.go
@@ -18,6 +18,17 @@ import (
 	"time"
 )
 
+// Event type constants
+const (
+	TypeBlock            = "input.block"
+	TypeTransaction      = "input.transaction"
+	TypeRollback         = "input.rollback"
+	TypeGovernance       = "input.governance"
+	TypeDRepRegistration = "input.drep-registration"
+	TypeDRepUpdate       = "input.drep-update"
+	TypeDRepRetirement   = "input.drep-retirement"
+)
+
 type Event struct {
 	Timestamp time.Time `json:"timestamp"`
 	Context   any       `json:"context,omitempty"`

--- a/examples/adder-publisher/README.md
+++ b/examples/adder-publisher/README.md
@@ -61,8 +61,8 @@ The program will output:
 Example:
 ```text
 ChainSync status update: {Status: syncing, Tip: 12345678}
-Received event: chainsync.block
-Received event: chainsync.transaction
+Received event: input.block
+Received event: input.transaction
 ...
 ```
 

--- a/examples/event-address-filter/README.md
+++ b/examples/event-address-filter/README.md
@@ -26,7 +26,7 @@ By default, this example connects to a remote IOG Cardano node. To use a local s
 
 Filters events to only include transactions:
 ```go
-filter_event.WithTypes([]string{"chainsync.transaction"})
+filter_event.WithTypes([]string{event.TypeTransaction})
 ```
 
 ### Address Filter
@@ -81,9 +81,9 @@ To disable asset filtering, comment out or remove the `WithAssetFingerprints` li
 ### Filter Other Event Types
 
 Available event types include:
-- `chainsync.block`
-- `chainsync.transaction`
-- `chainsync.rollback`
+- `input.block`
+- `input.transaction`
+- `input.rollback`
 
 ## Running
 
@@ -104,7 +104,7 @@ go run main.go
 The program will only output transaction events involving the specified address and/or assets:
 ```text
 ChainSync status update: {Status: syncing, Tip: 12345678}
-Received event: chainsync.transaction (involving filtered address/asset)
+Received event: input.transaction (involving filtered address/asset)
 ...
 ```
 

--- a/examples/event-address-filter/main.go
+++ b/examples/event-address-filter/main.go
@@ -66,7 +66,7 @@ func main() {
 
 	// Define type in event filter
 	filterEvent := filter_event.New(
-		filter_event.WithTypes([]string{"chainsync.transaction"}),
+		filter_event.WithTypes([]string{event.TypeTransaction}),
 	)
 	// Add event filter to pipeline
 	p.AddFilter(filterEvent)

--- a/examples/poolid-filter/README.md
+++ b/examples/poolid-filter/README.md
@@ -54,7 +54,7 @@ go run main.go
 The program will only output events related to the specified pools:
 ```text
 ChainSync status update: {Status: syncing, Tip: 12345678}
-Received event: chainsync.block (from filtered pool)
+Received event: input.block (from filtered pool)
 Received event: chainsync.delegation (to filtered pool)
 ...
 ```

--- a/examples/poolid-filter/README.md
+++ b/examples/poolid-filter/README.md
@@ -55,7 +55,7 @@ The program will only output events related to the specified pools:
 ```text
 ChainSync status update: {Status: syncing, Tip: 12345678}
 Received event: input.block (from filtered pool)
-Received event: chainsync.delegation (to filtered pool)
+Received event: input.transaction (involving filtered pool)
 ...
 ```
 

--- a/input/chainsync/chainsync.go
+++ b/input/chainsync/chainsync.go
@@ -417,7 +417,7 @@ func (c *ChainSync) handleRollBackward(
 ) error {
 	c.lastTip = tip
 	evt := event.New(
-		"input.rollback",
+		event.TypeRollback,
 		time.Now(),
 		nil,
 		event.NewRollbackEvent(point),
@@ -488,7 +488,7 @@ func (c *ChainSync) handleRollForward(
 		return errors.New("unknown type")
 	}
 	blockEvt := event.New(
-		"input.block",
+		event.TypeBlock,
 		time.Now(),
 		event.NewBlockHeaderContext(block.Header(), c.networkMagic),
 		event.NewBlockEvent(block, c.includeCbor),
@@ -508,7 +508,7 @@ func (c *ChainSync) handleRollForward(
 			return errors.New("invalid number of transactions")
 		}
 		txEvt := event.New(
-			"input.transaction",
+			event.TypeTransaction,
 			time.Now(),
 			event.NewTransactionContext(
 				block,
@@ -527,7 +527,7 @@ func (c *ChainSync) handleRollForward(
 		// Emit governance event if transaction contains governance data
 		if event.HasGovernanceData(transaction) {
 			govEvt := event.New(
-				"input.governance",
+				event.TypeGovernance,
 				time.Now(),
 				event.NewGovernanceContext(
 					block,
@@ -616,7 +616,7 @@ func (c *ChainSync) handleBlockFetchBlock(
 	block ledger.Block,
 ) error {
 	blockEvt := event.New(
-		"input.block",
+		event.TypeBlock,
 		time.Now(),
 		event.NewBlockContext(block, c.networkMagic),
 		event.NewBlockEvent(block, c.includeCbor),
@@ -636,7 +636,7 @@ func (c *ChainSync) handleBlockFetchBlock(
 			return errors.New("invalid number of transactions")
 		}
 		txEvt := event.New(
-			"input.transaction",
+			event.TypeTransaction,
 			time.Now(),
 			event.NewTransactionContext(
 				block,
@@ -655,7 +655,7 @@ func (c *ChainSync) handleBlockFetchBlock(
 		// Emit governance event if transaction contains governance data
 		if event.HasGovernanceData(transaction) {
 			govEvt := event.New(
-				"input.governance",
+				event.TypeGovernance,
 				time.Now(),
 				event.NewGovernanceContext(
 					block,

--- a/input/mempool/mempool.go
+++ b/input/mempool/mempool.go
@@ -367,7 +367,7 @@ func (m *Mempool) pollOnce() {
 		if resolveErr != nil && m.logger != nil {
 			m.logger.Warn("some transaction inputs could not be resolved; partial resolved inputs may be set", "error", resolveErr)
 		}
-		evt := event.New("input.transaction", time.Now(), ctx, payload)
+		evt := event.New(event.TypeTransaction, time.Now(), ctx, payload)
 		select {
 		case <-m.doneChan:
 			return

--- a/input/utxorpc/mapper.go
+++ b/input/utxorpc/mapper.go
@@ -63,7 +63,7 @@ func mapFollowTipResponse(resp *syncpb.FollowTipResponse, includeCbor bool, netw
 		}
 		return []event.Event{
 			event.New(
-				"input.rollback",
+				event.TypeRollback,
 				time.Now(),
 				nil,
 				event.NewRollbackEvent(common.NewPoint(header.GetSlot(), header.GetHash())),
@@ -74,7 +74,7 @@ func mapFollowTipResponse(resp *syncpb.FollowTipResponse, includeCbor bool, netw
 	if reset := resp.GetReset_(); reset != nil {
 		return []event.Event{
 			event.New(
-				"input.rollback",
+				event.TypeRollback,
 				time.Now(),
 				nil,
 				event.NewRollbackEvent(common.NewPoint(reset.GetSlot(), reset.GetHash())),
@@ -100,7 +100,7 @@ func followTipApplyCBOR(nativeBytes []byte, includeCbor bool, networkMagic uint3
 	txns := block.Transactions()
 	out := make([]event.Event, 0, 1+len(txns))
 	out = append(out, event.New(
-		"input.block",
+		event.TypeBlock,
 		time.Now(),
 		event.NewBlockHeaderContext(block.Header(), networkMagic),
 		event.NewBlockEvent(block, includeCbor),
@@ -112,14 +112,14 @@ func followTipApplyCBOR(nativeBytes []byte, includeCbor bool, networkMagic uint3
 		//nolint:gosec // t is bounds-checked above
 		idx := uint32(t)
 		out = append(out, event.New(
-			"input.transaction",
+			event.TypeTransaction,
 			time.Now(),
 			event.NewTransactionContext(block, transaction, idx, networkMagic),
 			event.NewTransactionEvent(block, transaction, includeCbor, nil),
 		))
 		if event.HasGovernanceData(transaction) {
 			out = append(out, event.New(
-				"input.governance",
+				event.TypeGovernance,
 				time.Now(),
 				event.NewGovernanceContext(block, transaction, idx, networkMagic),
 				event.NewGovernanceEvent(block, transaction, includeCbor),
@@ -154,7 +154,7 @@ func followTipApplyProtobuf(cb *cardanopb.Block, networkMagic uint32) ([]event.E
 	}
 	out := make([]event.Event, 0, 1+txCount)
 	out = append(out, event.New(
-		"input.block",
+		event.TypeBlock,
 		now,
 		pbBlockContext(header, networkMagic),
 		pbBlockEvent(cb),
@@ -172,14 +172,14 @@ func followTipApplyProtobuf(cb *cardanopb.Block, networkMagic uint32) ([]event.E
 		//nolint:gosec // t is bounds-checked above
 		idx := uint32(t)
 		out = append(out, event.New(
-			"input.transaction",
+			event.TypeTransaction,
 			now,
 			pbTransactionContext(header, txHash, idx, networkMagic),
 			pbTransactionEvent(blockHash, tx),
 		))
 		if hasGovernanceData(tx) {
 			out = append(out, event.New(
-				"input.governance",
+				event.TypeGovernance,
 				now,
 				pbGovernanceContext(header, txHash, idx, networkMagic),
 				pbGovernanceEvent(blockHash, tx),
@@ -232,7 +232,7 @@ func mapWatchTxResponse(resp *watchpb.WatchTxResponse, networkMagic uint32) ([]e
 		}
 		return []event.Event{
 			event.New(
-				"input.rollback",
+				event.TypeRollback,
 				time.Now(),
 				nil,
 				event.NewRollbackEvent(common.NewPoint(
@@ -301,7 +301,7 @@ func watchTxApplyProtobuf(
 
 	var out []event.Event
 	out = append(out, event.New(
-		"input.transaction",
+		event.TypeTransaction,
 		now,
 		pbTransactionContext(header, txHash, 0, networkMagic),
 		pbTransactionEvent(blockHash, tx),
@@ -309,7 +309,7 @@ func watchTxApplyProtobuf(
 
 	if hasGovernanceData(tx) {
 		out = append(out, event.New(
-			"input.governance",
+			event.TypeGovernance,
 			now,
 			pbGovernanceContext(header, txHash, 0, networkMagic),
 			pbGovernanceEvent(blockHash, tx),
@@ -366,11 +366,11 @@ func hasGovernanceData(tx *cardanopb.Tx) bool {
 func inputDRepEventType(certType string) (string, bool) {
 	switch certType {
 	case event.DRepCertificateTypeRegistration:
-		return "input.drep-registration", true
+		return event.TypeDRepRegistration, true
 	case event.DRepCertificateTypeUpdate:
-		return "input.drep-update", true
+		return event.TypeDRepUpdate, true
 	case event.DRepCertificateTypeDeregistration:
-		return "input.drep-retirement", true
+		return event.TypeDRepRetirement, true
 	default:
 		return "", false
 	}

--- a/input/utxorpc/mapper.go
+++ b/input/utxorpc/mapper.go
@@ -128,7 +128,7 @@ func followTipApplyCBOR(nativeBytes []byte, includeCbor bool, networkMagic uint3
 		if drepCerts := event.ExtractDRepCertificates(transaction); len(drepCerts) > 0 {
 			drepCtx := event.NewGovernanceContext(block, transaction, idx, networkMagic)
 			for _, cert := range drepCerts {
-				if evtType, ok := inputDRepEventType(cert.CertificateType); ok {
+				if evtType, ok := event.DRepEventType(cert.CertificateType); ok {
 					out = append(out, event.New(evtType, time.Now(), drepCtx,
 						event.NewDRepCertificateEvent(block, cert)))
 				}
@@ -189,7 +189,7 @@ func followTipApplyProtobuf(cb *cardanopb.Block, networkMagic uint32) ([]event.E
 		if len(drepCerts) > 0 {
 			drepCtx := pbGovernanceContext(header, txHash, idx, networkMagic)
 			for _, cert := range drepCerts {
-				if evtType, ok := inputDRepEventType(cert.CertificateType); ok {
+				if evtType, ok := event.DRepEventType(cert.CertificateType); ok {
 					out = append(out, event.New(
 						evtType,
 						now,
@@ -319,7 +319,7 @@ func watchTxApplyProtobuf(
 	if len(drepCerts) > 0 {
 		drepCtx := pbGovernanceContext(header, txHash, 0, networkMagic)
 		for _, cert := range drepCerts {
-			if evtType, ok := inputDRepEventType(cert.CertificateType); ok {
+			if evtType, ok := event.DRepEventType(cert.CertificateType); ok {
 				out = append(out, event.New(
 					evtType,
 					now,
@@ -361,17 +361,4 @@ func hasGovernanceData(tx *cardanopb.Tx) bool {
 		}
 	}
 	return false
-}
-
-func inputDRepEventType(certType string) (string, bool) {
-	switch certType {
-	case event.DRepCertificateTypeRegistration:
-		return event.TypeDRepRegistration, true
-	case event.DRepCertificateTypeUpdate:
-		return event.TypeDRepUpdate, true
-	case event.DRepCertificateTypeDeregistration:
-		return event.TypeDRepRetirement, true
-	default:
-		return "", false
-	}
 }

--- a/input/utxorpc/mapper_test.go
+++ b/input/utxorpc/mapper_test.go
@@ -63,7 +63,7 @@ func TestFollowTipApplyCBORRealProviderBlock(t *testing.T) {
 	require.NoError(t, err)
 	require.Greater(t, len(evts), 1, "should produce at least block + transaction events")
 
-	assert.Equal(t, "input.block", evts[0].Type)
+	assert.Equal(t, event.TypeBlock, evts[0].Type)
 
 	blockCtx := evts[0].Context.(event.BlockContext)
 	assert.Equal(t, uint64(13380271), blockCtx.BlockNumber)
@@ -75,7 +75,7 @@ func TestFollowTipApplyCBORRealProviderBlock(t *testing.T) {
 
 	for _, e := range evts[1:] {
 		assert.Contains(t,
-			[]string{"input.transaction", "input.governance", "input.drep-registration", "input.drep-update", "input.drep-retirement"},
+			[]string{event.TypeTransaction, event.TypeGovernance, event.TypeDRepRegistration, event.TypeDRepUpdate, event.TypeDRepRetirement},
 			e.Type,
 		)
 	}
@@ -95,10 +95,10 @@ func TestFollowTipApplyCBORFansOut(t *testing.T) {
 	evts, err := mapFollowTipResponse(resp, false, 764824073)
 	require.NoError(t, err)
 	require.Greater(t, len(evts), 1, "should produce at least block + transaction events")
-	assert.Equal(t, "input.block", evts[0].Type)
+	assert.Equal(t, event.TypeBlock, evts[0].Type)
 	for _, e := range evts[1:] {
 		assert.Contains(t,
-			[]string{"input.transaction", "input.governance", "input.drep-registration", "input.drep-update", "input.drep-retirement"},
+			[]string{event.TypeTransaction, event.TypeGovernance, event.TypeDRepRegistration, event.TypeDRepUpdate, event.TypeDRepRetirement},
 			e.Type,
 		)
 	}
@@ -204,8 +204,8 @@ func TestFollowTipApplyProtobufFansOut(t *testing.T) {
 	evts, err := mapFollowTipResponse(resp, false, 764824073)
 	require.NoError(t, err)
 	require.Len(t, evts, 2, "block + 1 transaction")
-	assert.Equal(t, "input.block", evts[0].Type)
-	assert.Equal(t, "input.transaction", evts[1].Type)
+	assert.Equal(t, event.TypeBlock, evts[0].Type)
+	assert.Equal(t, event.TypeTransaction, evts[1].Type)
 
 	blockEvt := evts[0].Payload.(event.BlockEvent)
 	assert.Equal(t, uint64(1), blockEvt.TransactionCount)
@@ -262,9 +262,9 @@ func TestFollowTipApplyProtobufGovernance(t *testing.T) {
 	evts, err := mapFollowTipResponse(resp, false, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 3, "block + tx + governance")
-	assert.Equal(t, "input.block", evts[0].Type)
-	assert.Equal(t, "input.transaction", evts[1].Type)
-	assert.Equal(t, "input.governance", evts[2].Type)
+	assert.Equal(t, event.TypeBlock, evts[0].Type)
+	assert.Equal(t, event.TypeTransaction, evts[1].Type)
+	assert.Equal(t, event.TypeGovernance, evts[2].Type)
 
 	govEvt := evts[2].Payload.(event.GovernanceEvent)
 	require.Len(t, govEvt.ProposalProcedures, 1)
@@ -317,7 +317,7 @@ func TestFollowTipUndoProducesRollback(t *testing.T) {
 	evts, err := mapFollowTipResponse(resp, false, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.rollback", evts[0].Type)
+	assert.Equal(t, event.TypeRollback, evts[0].Type)
 }
 
 func TestFollowTipUndoNativeBytesProducesRollback(t *testing.T) {
@@ -333,7 +333,7 @@ func TestFollowTipUndoNativeBytesProducesRollback(t *testing.T) {
 	evts, err := mapFollowTipResponse(resp, false, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.rollback", evts[0].Type)
+	assert.Equal(t, event.TypeRollback, evts[0].Type)
 
 	rb := evts[0].Payload.(event.RollbackEvent)
 	assert.Equal(t, block.SlotNumber(), rb.SlotNumber)
@@ -349,7 +349,7 @@ func TestFollowTipResetProducesRollback(t *testing.T) {
 	evts, err := mapFollowTipResponse(resp, false, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.rollback", evts[0].Type)
+	assert.Equal(t, event.TypeRollback, evts[0].Type)
 }
 
 // --------------- WatchTx: NativeBytes header extraction ---------------
@@ -376,7 +376,7 @@ func TestWatchTxApplyNativeBytesExtractsHeader(t *testing.T) {
 	evts, err := mapWatchTxResponse(resp, 764824073)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.transaction", evts[0].Type)
+	assert.Equal(t, event.TypeTransaction, evts[0].Type)
 
 	txCtx := evts[0].Context.(event.TransactionContext)
 	assert.Equal(t, block.SlotNumber(), txCtx.SlotNumber)
@@ -411,7 +411,7 @@ func TestWatchTxApplyProtobufWithHeader(t *testing.T) {
 	evts, err := mapWatchTxResponse(resp, 764824073)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.transaction", evts[0].Type)
+	assert.Equal(t, event.TypeTransaction, evts[0].Type)
 
 	txCtx := evts[0].Context.(event.TransactionContext)
 	assert.Equal(t, hex.EncodeToString(txHash), txCtx.TransactionHash)
@@ -440,7 +440,7 @@ func TestWatchTxApplyProtobufNoBlock(t *testing.T) {
 	evts, err := mapWatchTxResponse(resp, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.transaction", evts[0].Type)
+	assert.Equal(t, event.TypeTransaction, evts[0].Type)
 
 	txEvt := evts[0].Payload.(event.TransactionEvent)
 	assert.Equal(t, uint64(180000), txEvt.Fee)
@@ -497,11 +497,11 @@ func TestWatchTxApplyProtobufGovernance(t *testing.T) {
 	evts, err := mapWatchTxResponse(resp, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 5, "tx + governance + 3 drep events")
-	assert.Equal(t, "input.transaction", evts[0].Type)
-	assert.Equal(t, "input.governance", evts[1].Type)
-	assert.Equal(t, "input.drep-registration", evts[2].Type)
-	assert.Equal(t, "input.drep-update", evts[3].Type)
-	assert.Equal(t, "input.drep-retirement", evts[4].Type)
+	assert.Equal(t, event.TypeTransaction, evts[0].Type)
+	assert.Equal(t, event.TypeGovernance, evts[1].Type)
+	assert.Equal(t, event.TypeDRepRegistration, evts[2].Type)
+	assert.Equal(t, event.TypeDRepUpdate, evts[3].Type)
+	assert.Equal(t, event.TypeDRepRetirement, evts[4].Type)
 }
 
 // --------------- WatchTx: Undo / Idle ---------------
@@ -528,7 +528,7 @@ func TestWatchTxUndoEmitsRollback(t *testing.T) {
 	evts, err := mapWatchTxResponse(resp, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.rollback", evts[0].Type)
+	assert.Equal(t, event.TypeRollback, evts[0].Type)
 }
 
 func TestWatchTxUndoNeitherPathErrors(t *testing.T) {
@@ -565,7 +565,7 @@ func TestWatchTxUndoNativeBytesEmitsRollback(t *testing.T) {
 	evts, err := mapWatchTxResponse(resp, 0)
 	require.NoError(t, err)
 	require.Len(t, evts, 1)
-	assert.Equal(t, "input.rollback", evts[0].Type)
+	assert.Equal(t, event.TypeRollback, evts[0].Type)
 
 	rb := evts[0].Payload.(event.RollbackEvent)
 	assert.Equal(t, block.SlotNumber(), rb.SlotNumber)

--- a/output/log/log_test.go
+++ b/output/log/log_test.go
@@ -47,7 +47,7 @@ func TestLogToFile(t *testing.T) {
 	require.NoError(t, err)
 
 	evt := event.Event{
-		Type:      "input.block",
+		Type:      event.TypeBlock,
 		Timestamp: time.Date(2026, 5, 24, 12, 0, 0, 0, time.UTC),
 		Context: event.BlockContext{
 			BlockNumber: 100,
@@ -85,7 +85,7 @@ func TestFormatJSONOutput(t *testing.T) {
 	require.NoError(t, l.Start())
 
 	testEvent := event.New(
-		"input.block",
+		event.TypeBlock,
 		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		map[string]any{"blockNumber": 12345},
 		map[string]any{"hash": "abc123"},
@@ -107,7 +107,7 @@ func TestFormatJSONOutput(t *testing.T) {
 	err = json.Unmarshal([]byte(line), &parsed)
 	require.NoError(t, err, "output should be valid JSON: %s", line)
 
-	assert.Equal(t, "input.block", parsed.Type)
+	assert.Equal(t, event.TypeBlock, parsed.Type)
 	assert.Equal(
 		t,
 		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -127,7 +127,7 @@ func TestFormatJSONNoSlogWrapper(t *testing.T) {
 	require.NoError(t, l.Start())
 
 	testEvent := event.New(
-		"input.transaction",
+		event.TypeTransaction,
 		time.Now(),
 		nil,
 		map[string]any{"fee": 200000},
@@ -153,7 +153,7 @@ func TestFormatJSONNoSlogWrapper(t *testing.T) {
 	assert.Contains(t, raw, "type")
 	assert.Contains(t, raw, "timestamp")
 	assert.Contains(t, raw, "payload")
-	assert.Equal(t, "input.transaction", raw["type"])
+	assert.Equal(t, event.TypeTransaction, raw["type"])
 }
 
 func TestFormatTextBlock(t *testing.T) {
@@ -168,7 +168,7 @@ func TestFormatTextBlock(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"input.block",
+		event.TypeBlock,
 		ts,
 		event.BlockContext{
 			Era:         "Conway",
@@ -212,7 +212,7 @@ func TestFormatTextTransaction(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"input.transaction",
+		event.TypeTransaction,
 		ts,
 		event.TransactionContext{
 			TransactionHash: "deadbeef12345678",
@@ -251,7 +251,7 @@ func TestFormatTextRollback(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"input.rollback",
+		event.TypeRollback,
 		ts,
 		nil,
 		event.RollbackEvent{
@@ -285,7 +285,7 @@ func TestFormatTextGovernance(t *testing.T) {
 
 	ts := time.Date(2026, 1, 15, 14, 30, 45, 0, time.UTC)
 	testEvent := event.New(
-		"input.governance",
+		event.TypeGovernance,
 		ts,
 		event.GovernanceContext{
 			TransactionHash: "govtx12345678abc",

--- a/output/log/log_test.go
+++ b/output/log/log_test.go
@@ -107,7 +107,7 @@ func TestFormatJSONOutput(t *testing.T) {
 	err = json.Unmarshal([]byte(line), &parsed)
 	require.NoError(t, err, "output should be valid JSON: %s", line)
 
-	assert.Equal(t, event.TypeBlock, parsed.Type)
+	assert.Equal(t, "input.block", parsed.Type)
 	assert.Equal(
 		t,
 		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -153,7 +153,7 @@ func TestFormatJSONNoSlogWrapper(t *testing.T) {
 	assert.Contains(t, raw, "type")
 	assert.Contains(t, raw, "timestamp")
 	assert.Contains(t, raw, "payload")
-	assert.Equal(t, event.TypeTransaction, raw["type"])
+	assert.Equal(t, "input.transaction", raw["type"])
 }
 
 func TestFormatTextBlock(t *testing.T) {

--- a/output/notify/notify.go
+++ b/output/notify/notify.go
@@ -82,7 +82,7 @@ func (n *NotifyOutput) Start() error {
 				return
 			}
 			switch evt.Type {
-			case "input.block":
+			case event.TypeBlock:
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("block event has nil payload")
@@ -111,7 +111,7 @@ func (n *NotifyOutput) Start() error {
 					slog.Error("failed to send block notification", "error", err)
 					continue
 				}
-			case "input.rollback":
+			case event.TypeRollback:
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("rollback event has nil payload")
@@ -131,7 +131,7 @@ func (n *NotifyOutput) Start() error {
 					slog.Error("failed to send rollback notification", "error", err)
 					continue
 				}
-			case "input.transaction":
+			case event.TypeTransaction:
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("transaction event has nil payload")

--- a/output/notify/notify_test.go
+++ b/output/notify/notify_test.go
@@ -83,13 +83,13 @@ func TestNotifyOutputMalformedPayload(t *testing.T) {
 	}{
 		{
 			name:    "block event nil payload",
-			evt:     event.Event{Type: "input.block", Payload: nil},
+			evt:     event.Event{Type: event.TypeBlock, Payload: nil},
 			wantMsg: "block event has nil payload",
 		},
 		{
 			name: "block event nil context",
 			evt: event.Event{
-				Type:    "input.block",
+				Type:    event.TypeBlock,
 				Payload: event.BlockEvent{},
 				Context: nil,
 			},
@@ -97,18 +97,18 @@ func TestNotifyOutputMalformedPayload(t *testing.T) {
 		},
 		{
 			name:    "rollback event nil payload",
-			evt:     event.Event{Type: "input.rollback", Payload: nil},
+			evt:     event.Event{Type: event.TypeRollback, Payload: nil},
 			wantMsg: "rollback event has nil payload",
 		},
 		{
 			name:    "transaction event nil payload",
-			evt:     event.Event{Type: "input.transaction", Payload: nil},
+			evt:     event.Event{Type: event.TypeTransaction, Payload: nil},
 			wantMsg: "transaction event has nil payload",
 		},
 		{
 			name: "transaction event nil context",
 			evt: event.Event{
-				Type:    "input.transaction",
+				Type:    event.TypeTransaction,
 				Payload: event.TransactionEvent{},
 				Context: nil,
 			},

--- a/output/push/push.go
+++ b/output/push/push.go
@@ -148,7 +148,7 @@ func (p *PushOutput) Start() error {
 			}
 
 			switch evt.Type {
-			case "input.block":
+			case event.TypeBlock:
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("block event has nil payload")
@@ -184,7 +184,7 @@ func (p *PushOutput) Start() error {
 				// Send notification
 				p.processFcmNotifications(errorChan, title, body)
 
-			case "input.rollback":
+			case event.TypeRollback:
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("rollback event has nil payload")
@@ -199,7 +199,7 @@ func (p *PushOutput) Start() error {
 					"block_hash",
 					re.BlockHash,
 				)
-			case "input.transaction":
+			case event.TypeTransaction:
 				payload := evt.Payload
 				if payload == nil {
 					slog.Error("transaction event has nil payload")

--- a/output/push/push_test.go
+++ b/output/push/push_test.go
@@ -96,7 +96,7 @@ func TestPushOutput_FCMFailureSurfacesError(t *testing.T) {
 
 	// Send a block event
 	evt := event.Event{
-		Type: "input.block",
+		Type: event.TypeBlock,
 		Context: event.BlockContext{
 			BlockNumber: 100,
 			SlotNumber:  200,
@@ -197,7 +197,7 @@ func TestPushOutput_ShutdownDuringInFlightRequest(t *testing.T) {
 
 	// Send an event
 	evt := event.Event{
-		Type: "input.block",
+		Type: event.TypeBlock,
 		Context: event.BlockContext{
 			BlockNumber: 100,
 			SlotNumber:  200,

--- a/output/telegram/telegram.go
+++ b/output/telegram/telegram.go
@@ -228,7 +228,7 @@ func (t *TelegramOutput) processEvent(evt *event.Event) {
 
 	var message string
 	switch evt.Type {
-	case "input.block":
+	case event.TypeBlock:
 		evtCtx := evt.Context
 		if evtCtx == nil {
 			logger.Error("block event has nil context")
@@ -248,7 +248,7 @@ func (t *TelegramOutput) processEvent(evt *event.Event) {
 		baseURL := getBaseURL(bc.NetworkMagic)
 		message = formatBlockMessage(be, bc, baseURL, t.parseMode)
 
-	case "input.rollback":
+	case event.TypeRollback:
 		re, ok := payload.(event.RollbackEvent)
 		if !ok {
 			logger.Error("rollback event has invalid payload type")
@@ -256,7 +256,7 @@ func (t *TelegramOutput) processEvent(evt *event.Event) {
 		}
 		message = formatRollbackMessage(re, t.parseMode)
 
-	case "input.transaction":
+	case event.TypeTransaction:
 		evtCtx := evt.Context
 		if evtCtx == nil {
 			logger.Error("transaction event has nil context")
@@ -276,7 +276,7 @@ func (t *TelegramOutput) processEvent(evt *event.Event) {
 		baseURL := getBaseURL(tc.NetworkMagic)
 		message = formatTransactionMessage(te, tc, baseURL, t.parseMode)
 
-	case "input.governance":
+	case event.TypeGovernance:
 		evtCtx := evt.Context
 		if evtCtx == nil {
 			logger.Error("governance event has nil context")

--- a/output/telegram/telegram_test.go
+++ b/output/telegram/telegram_test.go
@@ -300,7 +300,7 @@ func TestProcessEventInvalidPayloadNoPanic(t *testing.T) {
 
 	// Wrong payload type for block — should log and return, not panic
 	evt := &event.Event{
-		Type:    "input.block",
+		Type:    event.TypeBlock,
 		Payload: "not a BlockEvent",
 		Context: event.BlockContext{
 			Era: "Conway", BlockNumber: 1, SlotNumber: 1, NetworkMagic: mainnetNetworkMagic,
@@ -309,7 +309,7 @@ func TestProcessEventInvalidPayloadNoPanic(t *testing.T) {
 	tg.processEvent(evt)
 
 	// Wrong payload type for rollback
-	evt2 := &event.Event{Type: "input.rollback", Payload: 12345}
+	evt2 := &event.Event{Type: event.TypeRollback, Payload: 12345}
 	tg.processEvent(evt2)
 
 	// Unknown event type

--- a/output/webhook/webhook.go
+++ b/output/webhook/webhook.go
@@ -123,7 +123,7 @@ func (w *WebhookOutput) Start() error {
 				}
 				context := evt.Context
 				switch evt.Type {
-				case "input.block":
+				case event.TypeBlock:
 					if context == nil {
 						w.reportError(
 							logger,
@@ -151,7 +151,7 @@ func (w *WebhookOutput) Start() error {
 						)
 						continue
 					}
-				case "input.rollback":
+				case event.TypeRollback:
 					if _, ok := payload.(event.RollbackEvent); !ok {
 						w.reportError(
 							logger,
@@ -160,7 +160,7 @@ func (w *WebhookOutput) Start() error {
 						)
 						continue
 					}
-				case "input.transaction":
+				case event.TypeTransaction:
 					if _, ok := payload.(event.TransactionEvent); !ok {
 						w.reportError(
 							logger,
@@ -177,7 +177,7 @@ func (w *WebhookOutput) Start() error {
 						)
 						continue
 					}
-				case "input.governance":
+				case event.TypeGovernance:
 					if _, ok := payload.(event.GovernanceEvent); !ok {
 						w.reportError(
 							logger,
@@ -257,7 +257,7 @@ func formatWebhook(e *event.Event, format string) ([]byte, error) {
 		dmes := make([]*DiscordMessageEmbed, 0, 1)
 		var dmefs []*DiscordMessageEmbedField
 		switch e.Type {
-		case "input.block":
+		case event.TypeBlock:
 			be, ok := e.Payload.(event.BlockEvent)
 			if !ok {
 				return nil, unexpectedPayloadErr(e.Type, e.Payload)
@@ -285,7 +285,7 @@ func formatWebhook(e *event.Event, format string) ([]byte, error) {
 			})
 			baseURL := getBaseURL(bc.NetworkMagic)
 			dme.URL = fmt.Sprintf("%s/block/%s", baseURL, be.BlockHash)
-		case "input.rollback":
+		case event.TypeRollback:
 			be, ok := e.Payload.(event.RollbackEvent)
 			if !ok {
 				return nil, unexpectedPayloadErr(e.Type, e.Payload)
@@ -299,7 +299,7 @@ func formatWebhook(e *event.Event, format string) ([]byte, error) {
 				Name:  "Block Hash",
 				Value: be.BlockHash,
 			})
-		case "input.transaction":
+		case event.TypeTransaction:
 			te, ok := e.Payload.(event.TransactionEvent)
 			if !ok {
 				return nil, unexpectedPayloadErr(e.Type, e.Payload)
@@ -335,7 +335,7 @@ func formatWebhook(e *event.Event, format string) ([]byte, error) {
 			})
 			baseURL := getBaseURL(tc.NetworkMagic)
 			dme.URL = fmt.Sprintf("%s/tx/%s", baseURL, tc.TransactionHash)
-		case "input.governance":
+		case event.TypeGovernance:
 			ge, ok := e.Payload.(event.GovernanceEvent)
 			if !ok {
 				return nil, unexpectedPayloadErr(e.Type, e.Payload)

--- a/output/webhook/webhook_test.go
+++ b/output/webhook/webhook_test.go
@@ -65,7 +65,7 @@ func TestFormatWebhookAdderSuccess(t *testing.T) {
 
 	var parsed event.Event
 	require.NoError(t, json.Unmarshal(data, &parsed))
-	assert.Equal(t, event.TypeBlock, parsed.Type)
+	assert.Equal(t, "input.block", parsed.Type)
 }
 
 func TestFormatWebhookDiscordSuccess(t *testing.T) {

--- a/output/webhook/webhook_test.go
+++ b/output/webhook/webhook_test.go
@@ -40,7 +40,7 @@ func fastRetry() WebhookOptionFunc {
 
 func blockEvent() event.Event {
 	return event.New(
-		"input.block",
+		event.TypeBlock,
 		time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
 		event.BlockContext{
 			Era:          "Conway",
@@ -65,7 +65,7 @@ func TestFormatWebhookAdderSuccess(t *testing.T) {
 
 	var parsed event.Event
 	require.NoError(t, json.Unmarshal(data, &parsed))
-	assert.Equal(t, "input.block", parsed.Type)
+	assert.Equal(t, event.TypeBlock, parsed.Type)
 }
 
 func TestFormatWebhookDiscordSuccess(t *testing.T) {
@@ -76,18 +76,18 @@ func TestFormatWebhookDiscordSuccess(t *testing.T) {
 		{"block", blockEvent()},
 		{
 			"rollback",
-			event.New("input.rollback", time.Now(), nil,
+			event.New(event.TypeRollback, time.Now(), nil,
 				event.RollbackEvent{BlockHash: "abc", SlotNumber: 5}),
 		},
 		{
 			"transaction",
-			event.New("input.transaction", time.Now(),
+			event.New(event.TypeTransaction, time.Now(),
 				event.TransactionContext{TransactionHash: "tx", BlockNumber: 1},
 				event.TransactionEvent{Fee: 10}),
 		},
 		{
 			"governance",
-			event.New("input.governance", time.Now(),
+			event.New(event.TypeGovernance, time.Now(),
 				event.GovernanceContext{TransactionHash: "gtx", BlockNumber: 1},
 				event.GovernanceEvent{}),
 		},

--- a/tray/app.go
+++ b/tray/app.go
@@ -961,13 +961,13 @@ func (a *App) reconfigurePlan() (setup.SetupPlan, error) {
 
 func getEmojiForType(evtType string) string {
 	switch evtType {
-	case "input.block":
+	case event.TypeBlock:
 		return "🧱"
-	case "input.transaction":
+	case event.TypeTransaction:
 		return "💸"
-	case "input.governance":
+	case event.TypeGovernance:
 		return "🗳️"
-	case "input.rollback":
+	case event.TypeRollback:
 		return "🔄"
 	default:
 		return "❓"
@@ -1154,7 +1154,7 @@ func getExplorerURL(e event.Event, hash string) string {
 	}
 	baseURL := explorer.BaseURL(magic)
 
-	if e.Type == "input.transaction" || e.Type == "input.governance" {
+	if e.Type == event.TypeTransaction || e.Type == event.TypeGovernance {
 		return fmt.Sprintf("%s/tx/%s", baseURL, hash)
 	}
 	return fmt.Sprintf("%s/block/%s", baseURL, hash)
@@ -1167,7 +1167,7 @@ func getExplorerURL(e event.Event, hash string) string {
 // payloads also carry blockHash.
 func explorerHash(e event.Event) string {
 	switch e.Type {
-	case "input.transaction", "input.governance":
+	case event.TypeTransaction, event.TypeGovernance:
 		if ctx, ok := e.Context.(map[string]any); ok {
 			if h, ok := ctx["transactionHash"].(string); ok {
 				return h

--- a/tray/notifications/rules.go
+++ b/tray/notifications/rules.go
@@ -36,10 +36,10 @@ import (
 // emitted by adder's input plugins (see the event package); the tray.*
 // values are synthesized by the engine for non-chain notifications.
 const (
-	EventTypeBlock       = "input.block"
-	EventTypeTransaction = "input.transaction"
-	EventTypeGovernance  = "input.governance"
-	EventTypeRollback    = "input.rollback"
+	EventTypeBlock       = event.TypeBlock
+	EventTypeTransaction = event.TypeTransaction
+	EventTypeGovernance  = event.TypeGovernance
+	EventTypeRollback    = event.TypeRollback
 	// EventTypeConnection is a synthesized event type used to route
 	// connection-status notifications through the same rule pipeline as
 	// chain events. See Engine.NotifyConnection and ConnectionEvent.


### PR DESCRIPTION
…verywhere (#775)

Define exported, public constants for all event types in the event package (TypeBlock, TypeTransaction, etc.) to replace hardcoded strings and avoid downstream consumer out-of-sync bugs.

Adopted these constants across:
- event package and DRep event types
- input plugins (chainsync, mempool, and utxorpc)
- output plugins (log, notify, push, telegram, and webhook)
- tray application (rules and app views)
- examples, tests, and documentation

Resolves: #775

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose public event type constants in the `event` package and replace hardcoded strings across the codebase to prevent drift. DRep certificate events now use `input.drep-*`, and `input/utxorpc` uses the shared `event.DRepEventType` mapping.

- **New Features**
  - Added `event.TypeBlock`, `event.TypeTransaction`, `event.TypeRollback`, `event.TypeGovernance`, `event.TypeDRepRegistration`, `event.TypeDRepUpdate`, `event.TypeDRepRetirement`.
  - Adopted constants across `input/chainsync`, `input/mempool`, `input/utxorpc` (centralized DRep mapping via `event.DRepEventType`), `output/log`, `output/notify`, `output/push`, `output/telegram`, `output/webhook`, `tray`, examples, tests, and docs.

- **Migration**
  - Replace string literals with constants (e.g., use `event.TypeBlock` instead of `"input.block"`).
  - Update DRep filters/rules from `chainsync.drep.{registration|update|deregistration}` to `input.drep-{registration|update|retirement}`.

<sup>Written for commit e6898c42b840c274e159e3ff49ddd10fec7e6fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added standardized event type definitions for blocks, transactions, rollbacks, governance, and DRep activity.
  * Unified event naming across event delivery, notifications, webhooks, Telegram, tray integrations, and other outputs.
  * DRep events now use consistent registration, update, and retirement names.

* **Documentation**
  * Updated filtering guides and examples to reflect the standardized `input.*` event names.
  * Corrected sample outputs and supported event lists across documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->