### PR TITLE
feat: add headless notification integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,11 +210,17 @@ logs to stderr:
 
 ```bash
 adder \
+  --input chainsync \
+  --input-chainsync-network preview \
   --output notify-json \
   --output-notify-json-config ~/.config/adder/omarchy.json \
   --api-address 127.0.0.1 \
   --api-port 0
 ```
+
+The Chainsync network must match `network.name` in the notification JSON. When
+using a custom node, pass the same `host:port` with
+`--input-chainsync-address`; Adder rejects mismatches before starting.
 
 Validate the configuration before starting or restarting a frontend:
 

--- a/README.md
+++ b/README.md
@@ -201,6 +201,34 @@ adder --output-log-format json 2>/dev/null | jq .
 adder > /dev/null
 ```
 
+### Target-aware notification stream
+
+Desktop integrations can reuse the same target-aware rules as `adder-tray`
+without linking a GUI toolkit. The `notify-json` output reserves stdout for
+versioned newline-delimited status and notification records and writes runtime
+logs to stderr:
+
+```bash
+adder \
+  --output notify-json \
+  --output-notify-json-config ~/.config/adder/omarchy.json \
+  --api-address 127.0.0.1 \
+  --api-port 0
+```
+
+Validate the configuration before starting or restarting a frontend:
+
+```bash
+adder notifications validate \
+  --config ~/.config/adder/omarchy.json \
+  --json
+```
+
+The JSON configuration has `schemaVersion: 1` and describes the Cardano
+network, monitored wallets/DReps/pools/assets/policies, alert categories, rate
+limit, and connection-staleness threshold. An empty target set is rejected
+unless `monitor.everything` is explicitly enabled.
+
 ## Configuration
 
 Adder supports multiple configuration methods for versatility: commandline

--- a/cmd/adder/main.go
+++ b/cmd/adder/main.go
@@ -136,6 +136,9 @@ func run(cmd *cobra.Command) error {
 	if err := plugin.ProcessEnvVars(); err != nil {
 		return fmt.Errorf("failed to process env vars: %w", err)
 	}
+	if err := validateNotificationInput(cmd, cfg.Input, cfg.Output); err != nil {
+		return err
+	}
 
 	// Configure logging
 	logging.Configure()

--- a/cmd/adder/main.go
+++ b/cmd/adder/main.go
@@ -50,7 +50,7 @@ transactions, rollbacks, and governance actions. It uses a plugin-based
 pipeline architecture with configurable inputs, filters, and outputs.
 
 Input plugins:  chainsync (default), mempool
-Output plugins: log (default), webhook, telegram, push, notify
+Output plugins: log (default), webhook, telegram, push, notify, notify-json
 Filters:        address, asset, policy, pool, drep, event type
 
 Events are also available via the /events WebSocket/SSE API endpoint.`,
@@ -96,6 +96,7 @@ func init() {
 	if err := cfg.BindFlags(rootCmd.Flags()); err != nil {
 		panic(err)
 	}
+	rootCmd.AddCommand(newNotificationsCmd())
 }
 
 func run(cmd *cobra.Command) error {

--- a/cmd/adder/notifications.go
+++ b/cmd/adder/notifications.go
@@ -29,6 +29,61 @@ type notificationValidationResult struct {
 	Errors        []setup.ValidationIssue `json:"errors,omitempty"`
 }
 
+func validateNotificationInput(
+	cmd *cobra.Command,
+	inputName string,
+	outputName string,
+) error {
+	if outputName != "notify-json" {
+		return nil
+	}
+	if inputName != "chainsync" {
+		return fmt.Errorf("notify-json requires chainsync input, got %q", inputName)
+	}
+	configPath, err := cmd.Flags().GetString("output-notify-json-config")
+	if err != nil {
+		return err
+	}
+	if configPath == "" {
+		return errors.New("notify-json config path must not be empty")
+	}
+	cfg, err := setup.ReadNotificationConfig(configPath)
+	if err != nil {
+		return err
+	}
+	inputNetwork, err := cmd.Flags().GetString("input-chainsync-network")
+	if err != nil {
+		return err
+	}
+	if inputNetwork != cfg.Network.Name {
+		return fmt.Errorf(
+			"notification network %q does not match chainsync network %q",
+			cfg.Network.Name,
+			inputNetwork,
+		)
+	}
+	if cfg.Network.CustomAddress == "" {
+		return nil
+	}
+	inputAddress, err := cmd.Flags().GetString("input-chainsync-address")
+	if err != nil {
+		return err
+	}
+	expectedAddress := fmt.Sprintf(
+		"%s:%d",
+		cfg.Network.CustomAddress,
+		cfg.Network.CustomPort,
+	)
+	if inputAddress != expectedAddress {
+		return fmt.Errorf(
+			"notification custom node %q does not match chainsync address %q",
+			expectedAddress,
+			inputAddress,
+		)
+	}
+	return nil
+}
+
 func newNotificationsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "notifications",

--- a/cmd/adder/notifications.go
+++ b/cmd/adder/notifications.go
@@ -1,0 +1,83 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/blinklabs-io/adder/tray/setup"
+	"github.com/spf13/cobra"
+)
+
+type notificationValidationResult struct {
+	SchemaVersion int                     `json:"schemaVersion"`
+	Valid         bool                    `json:"valid"`
+	Errors        []setup.ValidationIssue `json:"errors,omitempty"`
+}
+
+func newNotificationsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "notifications",
+		Short: "Manage target-aware notification configuration",
+	}
+	var path string
+	var jsonOutput bool
+	validate := &cobra.Command{
+		Use:   "validate",
+		Short: "Validate a notification JSON configuration",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if path == "" {
+				return errors.New("--config is required")
+			}
+			_, err := setup.ReadNotificationConfig(path)
+			result := notificationValidationResult{
+				SchemaVersion: setup.NotificationConfigSchemaVersion,
+				Valid:         err == nil,
+			}
+			if err != nil {
+				var validationErr setup.ValidationIssuesError
+				if errors.As(err, &validationErr) {
+					result.Errors = validationErr.Issues
+				} else {
+					result.Errors = []setup.ValidationIssue{{
+						Field: "config", Message: err.Error(),
+					}}
+				}
+			}
+			if jsonOutput {
+				if encodeErr := json.NewEncoder(cmd.OutOrStdout()).Encode(result); encodeErr != nil {
+					return fmt.Errorf("encoding validation result: %w", encodeErr)
+				}
+			} else if err == nil {
+				fmt.Fprintln(cmd.OutOrStdout(), "notification configuration is valid")
+			} else {
+				for _, issue := range result.Errors {
+					fmt.Fprintf(cmd.OutOrStdout(), "%s: %s\n", issue.Field, issue.Message)
+				}
+			}
+			if err != nil {
+				return errors.New("notification configuration is invalid")
+			}
+			return nil
+		},
+	}
+	validate.Flags().StringVar(&path, "config", "", "path to notification JSON configuration")
+	validate.Flags().BoolVar(&jsonOutput, "json", false, "emit a machine-readable validation result")
+	cmd.AddCommand(validate)
+	return cmd
+}

--- a/cmd/adder/notifications.go
+++ b/cmd/adder/notifications.go
@@ -18,6 +18,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
 
 	"github.com/blinklabs-io/adder/tray/setup"
 	"github.com/spf13/cobra"
@@ -27,6 +30,23 @@ type notificationValidationResult struct {
 	SchemaVersion int                     `json:"schemaVersion"`
 	Valid         bool                    `json:"valid"`
 	Errors        []setup.ValidationIssue `json:"errors,omitempty"`
+}
+
+func normalizeHostPort(address string) (string, error) {
+	host, portText, err := net.SplitHostPort(address)
+	if err != nil {
+		return "", err
+	}
+	port, err := strconv.ParseUint(portText, 10, 16)
+	if err != nil {
+		return "", err
+	}
+	if ip := net.ParseIP(host); ip != nil {
+		host = ip.String()
+	} else {
+		host = strings.ToLower(host)
+	}
+	return net.JoinHostPort(host, strconv.FormatUint(port, 10)), nil
 }
 
 func validateNotificationInput(
@@ -69,12 +89,19 @@ func validateNotificationInput(
 	if err != nil {
 		return err
 	}
-	expectedAddress := fmt.Sprintf(
-		"%s:%d",
+	expectedAddress := net.JoinHostPort(
 		cfg.Network.CustomAddress,
-		cfg.Network.CustomPort,
+		strconv.FormatUint(uint64(cfg.Network.CustomPort), 10),
 	)
-	if inputAddress != expectedAddress {
+	normalizedExpected, err := normalizeHostPort(expectedAddress)
+	if err != nil {
+		return fmt.Errorf("invalid notification custom node %q: %w", expectedAddress, err)
+	}
+	normalizedInput, err := normalizeHostPort(inputAddress)
+	if err != nil {
+		return fmt.Errorf("invalid chainsync address %q: %w", inputAddress, err)
+	}
+	if normalizedInput != normalizedExpected {
 		return fmt.Errorf(
 			"notification custom node %q does not match chainsync address %q",
 			expectedAddress,

--- a/cmd/adder/notifications_test.go
+++ b/cmd/adder/notifications_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/blinklabs-io/adder/tray/setup"
+	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/require"
 )
 
@@ -68,4 +69,62 @@ func TestNotificationsValidateJSONReportsIssues(t *testing.T) {
 	require.False(t, result.Valid)
 	require.NotEmpty(t, result.Errors)
 	require.Equal(t, "schemaVersion", result.Errors[0].Field)
+}
+
+func TestValidateNotificationInput(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		inputNetwork  string
+		inputAddress  string
+		customAddress string
+		customPort    uint
+		expectedError string
+	}{
+		{
+			name:         "preview",
+			inputNetwork: "preview",
+		},
+		{
+			name:          "network mismatch",
+			inputNetwork:  "mainnet",
+			expectedError: "does not match chainsync network",
+		},
+		{
+			name:          "custom node mismatch",
+			inputNetwork:  "preview",
+			customAddress: "node.example",
+			customPort:    3001,
+			expectedError: "does not match chainsync address",
+		},
+		{
+			name:          "custom node",
+			inputNetwork:  "preview",
+			inputAddress:  "node.example:3001",
+			customAddress: "node.example",
+			customPort:    3001,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			cfg := setup.DefaultNotificationConfig()
+			cfg.Network.Name = "preview"
+			cfg.Network.CustomAddress = test.customAddress
+			cfg.Network.CustomPort = test.customPort
+			cfg.Monitor.Everything = true
+
+			cmd := &cobra.Command{}
+			cmd.Flags().String(
+				"output-notify-json-config",
+				writeNotificationConfig(t, cfg),
+				"",
+			)
+			cmd.Flags().String("input-chainsync-network", test.inputNetwork, "")
+			cmd.Flags().String("input-chainsync-address", test.inputAddress, "")
+			err := validateNotificationInput(cmd, "chainsync", "notify-json")
+			if test.expectedError == "" {
+				require.NoError(t, err)
+			} else {
+				require.ErrorContains(t, err, test.expectedError)
+			}
+		})
+	}
 }

--- a/cmd/adder/notifications_test.go
+++ b/cmd/adder/notifications_test.go
@@ -92,6 +92,7 @@ func TestValidateNotificationInput(t *testing.T) {
 		{
 			name:          "custom node mismatch",
 			inputNetwork:  "preview",
+			inputAddress:  "other.example:3001",
 			customAddress: "node.example",
 			customPort:    3001,
 			expectedError: "does not match chainsync address",
@@ -101,6 +102,20 @@ func TestValidateNotificationInput(t *testing.T) {
 			inputNetwork:  "preview",
 			inputAddress:  "node.example:3001",
 			customAddress: "node.example",
+			customPort:    3001,
+		},
+		{
+			name:          "IPv6 custom node",
+			inputNetwork:  "preview",
+			inputAddress:  "[::1]:3001",
+			customAddress: "::1",
+			customPort:    3001,
+		},
+		{
+			name:          "equivalent IPv6 custom node",
+			inputNetwork:  "preview",
+			inputAddress:  "[0:0:0:0:0:0:0:1]:3001",
+			customAddress: "::1",
 			customPort:    3001,
 		},
 	} {

--- a/cmd/adder/notifications_test.go
+++ b/cmd/adder/notifications_test.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/blinklabs-io/adder/tray/setup"
+	"github.com/stretchr/testify/require"
+)
+
+func writeNotificationConfig(t *testing.T, cfg setup.NotificationConfig) string {
+	t.Helper()
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "notifications.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func runNotificationValidation(
+	t *testing.T,
+	path string,
+) (notificationValidationResult, error) {
+	t.Helper()
+	cmd := newNotificationsCmd()
+	cmd.SilenceUsage = true
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"validate", "--config", path, "--json"})
+	err := cmd.Execute()
+	var result notificationValidationResult
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &result))
+	return result, err
+}
+
+func TestNotificationsValidateJSON(t *testing.T) {
+	cfg := setup.DefaultNotificationConfig()
+	cfg.Monitor.Everything = true
+	result, err := runNotificationValidation(t, writeNotificationConfig(t, cfg))
+	require.NoError(t, err)
+	require.True(t, result.Valid)
+	require.Empty(t, result.Errors)
+}
+
+func TestNotificationsValidateJSONReportsIssues(t *testing.T) {
+	cfg := setup.DefaultNotificationConfig()
+	cfg.SchemaVersion = 2
+	result, err := runNotificationValidation(t, writeNotificationConfig(t, cfg))
+	require.ErrorContains(t, err, "configuration is invalid")
+	require.False(t, result.Valid)
+	require.NotEmpty(t, result.Errors)
+	require.Equal(t, "schemaVersion", result.Errors[0].Field)
+}

--- a/output/notifyjson/notifyjson.go
+++ b/output/notifyjson/notifyjson.go
@@ -51,9 +51,10 @@ type notificationRecord struct {
 }
 
 type Output struct {
-	configPath string
-	writer     io.Writer
-	staleAfter time.Duration
+	configPath         string
+	writer             io.Writer
+	staleAfter         time.Duration
+	staleAfterOverride time.Duration
 
 	eventChan chan event.Event
 	errorChan chan error
@@ -82,6 +83,7 @@ func (o *Output) Start() error {
 		return err
 	}
 	o.config = cfg
+	o.staleAfter = o.staleAfterOverride
 	if o.staleAfter <= 0 {
 		o.staleAfter = time.Duration(cfg.ConnectionStaleSeconds) * time.Second
 	}

--- a/output/notifyjson/notifyjson.go
+++ b/output/notifyjson/notifyjson.go
@@ -123,9 +123,6 @@ func (o *Output) eventLoop(engineEvents chan<- event.Event) {
 	defer close(engineEvents)
 
 	timer := time.NewTimer(o.staleAfter)
-	if !timer.Stop() {
-		<-timer.C
-	}
 	defer timer.Stop()
 	connected := false
 	everConnected := false
@@ -178,16 +175,19 @@ func (o *Output) eventLoop(engineEvents chan<- event.Event) {
 				return
 			}
 		case <-timer.C:
+			message := "no chain events received before startup timeout"
+			if connected {
+				message = "no chain events received recently"
+			}
+			o.reportWriteError(o.writeRecord(statusRecord{
+				SchemaVersion: schemaVersion,
+				Kind:          "status",
+				Status:        "stale",
+				Timestamp:     time.Now().UTC(),
+				Message:       message,
+			}))
 			if connected {
 				connected = false
-				message := "no chain events received recently"
-				o.reportWriteError(o.writeRecord(statusRecord{
-					SchemaVersion: schemaVersion,
-					Kind:          "status",
-					Status:        "stale",
-					Timestamp:     time.Now().UTC(),
-					Message:       message,
-				}))
 				o.engine.NotifyConnection(
 					"Adder Connection",
 					"Lost connection to "+o.config.NetworkLabel(),

--- a/output/notifyjson/notifyjson.go
+++ b/output/notifyjson/notifyjson.go
@@ -1,0 +1,307 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notifyjson
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/adder/tray/notifications"
+	"github.com/blinklabs-io/adder/tray/setup"
+)
+
+const schemaVersion = 1
+
+type statusRecord struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	Kind          string    `json:"kind"`
+	Status        string    `json:"status"`
+	Timestamp     time.Time `json:"timestamp"`
+	Message       string    `json:"message,omitempty"`
+}
+
+type notificationRecord struct {
+	SchemaVersion int       `json:"schemaVersion"`
+	Kind          string    `json:"kind"`
+	Timestamp     time.Time `json:"timestamp"`
+	RuleID        string    `json:"ruleId"`
+	EventType     string    `json:"eventType,omitempty"`
+	Title         string    `json:"title"`
+	Body          string    `json:"body"`
+	Batched       bool      `json:"batched"`
+	Count         int       `json:"count"`
+}
+
+type Output struct {
+	configPath string
+	writer     io.Writer
+	staleAfter time.Duration
+
+	eventChan chan event.Event
+	errorChan chan error
+	done      chan struct{}
+	stopOnce  sync.Once
+	wg        sync.WaitGroup
+	writeMu   sync.Mutex
+	engine    *notifications.Engine
+	config    setup.NotificationConfig
+}
+
+func New(options ...Option) *Output {
+	o := &Output{writer: os.Stdout}
+	for _, option := range options {
+		option(o)
+	}
+	return o
+}
+
+func (o *Output) Start() error {
+	if o.configPath == "" {
+		return errors.New("notify-json config path must not be empty")
+	}
+	cfg, err := setup.ReadNotificationConfig(o.configPath)
+	if err != nil {
+		return err
+	}
+	o.config = cfg
+	if o.staleAfter <= 0 {
+		o.staleAfter = time.Duration(cfg.ConnectionStaleSeconds) * time.Second
+	}
+	o.eventChan = make(chan event.Event, 64)
+	o.errorChan = make(chan error, 8)
+	o.done = make(chan struct{})
+	o.stopOnce = sync.Once{}
+
+	engineEvents := make(chan event.Event, 64)
+	plan := cfg.SetupPlan()
+	o.engine = notifications.NewEngine(
+		engineEvents,
+		notifications.RulesFromPlan(plan),
+		notifications.WithRateLimit(
+			plan.App.NotifyRateLimit,
+			plan.App.NotifyRateWindow,
+		),
+	)
+	o.engine.Start()
+	if err := o.writeRecord(statusRecord{
+		SchemaVersion: schemaVersion,
+		Kind:          "status",
+		Status:        "starting",
+		Timestamp:     time.Now().UTC(),
+		Message:       "waiting for the first chain event",
+	}); err != nil {
+		o.engine.Stop()
+		return fmt.Errorf("writing initial status: %w", err)
+	}
+
+	o.wg.Add(2)
+	go o.eventLoop(engineEvents)
+	go o.requestLoop()
+	return nil
+}
+
+func (o *Output) eventLoop(engineEvents chan<- event.Event) {
+	defer o.wg.Done()
+	defer close(engineEvents)
+
+	timer := time.NewTimer(o.staleAfter)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	defer timer.Stop()
+	connected := false
+	everConnected := false
+
+	resetTimer := func() {
+		if !timer.Stop() {
+			select {
+			case <-timer.C:
+			default:
+			}
+		}
+		timer.Reset(o.staleAfter)
+	}
+
+	for {
+		select {
+		case <-o.done:
+			return
+		case evt := <-o.eventChan:
+			if !connected {
+				message := "receiving chain events from " + o.config.NetworkLabel()
+				o.reportWriteError(o.writeRecord(statusRecord{
+					SchemaVersion: schemaVersion,
+					Kind:          "status",
+					Status:        "connected",
+					Timestamp:     time.Now().UTC(),
+					Message:       message,
+				}))
+				if everConnected {
+					o.engine.NotifyConnection(
+						"Adder Connection",
+						"Reconnected to "+o.config.NetworkLabel(),
+					)
+				}
+				connected = true
+				everConnected = true
+			}
+			resetTimer()
+			normalized, err := normalizeEvent(evt)
+			if err != nil {
+				o.reportError(fmt.Errorf(
+					"normalizing event for notification rules: %w",
+					err,
+				))
+				continue
+			}
+			select {
+			case engineEvents <- normalized:
+			case <-o.done:
+				return
+			}
+		case <-timer.C:
+			if connected {
+				connected = false
+				message := "no chain events received recently"
+				o.reportWriteError(o.writeRecord(statusRecord{
+					SchemaVersion: schemaVersion,
+					Kind:          "status",
+					Status:        "stale",
+					Timestamp:     time.Now().UTC(),
+					Message:       message,
+				}))
+				o.engine.NotifyConnection(
+					"Adder Connection",
+					"Lost connection to "+o.config.NetworkLabel(),
+				)
+			}
+		}
+	}
+}
+
+// normalizeEvent gives typed ChainSync events the same shape as events decoded
+// from adder-tray's JSON WebSocket. Already-normalized events take the fast
+// path; native event structs use a JSON round-trip to preserve their stable
+// field names and the map/slice shapes expected by target matchers.
+func normalizeEvent(evt event.Event) (event.Event, error) {
+	if isNormalizedJSON(evt.Context) && isNormalizedJSON(evt.Payload) {
+		return evt, nil
+	}
+	data, err := json.Marshal(evt)
+	if err != nil {
+		return event.Event{}, err
+	}
+	var normalized event.Event
+	if err := json.Unmarshal(data, &normalized); err != nil {
+		return event.Event{}, err
+	}
+	return normalized, nil
+}
+
+func isNormalizedJSON(value any) bool {
+	switch value := value.(type) {
+	case nil, bool, float64, string:
+		return true
+	case []any:
+		for _, item := range value {
+			if !isNormalizedJSON(item) {
+				return false
+			}
+		}
+		return true
+	case map[string]any:
+		for _, item := range value {
+			if !isNormalizedJSON(item) {
+				return false
+			}
+		}
+		return true
+	default:
+		return false
+	}
+}
+
+func (o *Output) requestLoop() {
+	defer o.wg.Done()
+	for req := range o.engine.Requests() {
+		if req.Epoch < o.engine.CurrentEpoch() {
+			o.engine.RecordDrop()
+			continue
+		}
+		title := req.Title
+		if title == "" {
+			title = "Adder"
+		}
+		o.reportWriteError(o.writeRecord(notificationRecord{
+			SchemaVersion: schemaVersion,
+			Kind:          "notification",
+			Timestamp:     time.Now().UTC(),
+			RuleID:        req.RuleID,
+			EventType:     req.Event.Type,
+			Title:         title,
+			Body:          req.Body,
+			Batched:       req.Batched,
+			Count:         req.Count,
+		}))
+	}
+}
+
+func (o *Output) writeRecord(record any) error {
+	o.writeMu.Lock()
+	defer o.writeMu.Unlock()
+	return json.NewEncoder(o.writer).Encode(record)
+}
+
+func (o *Output) reportWriteError(err error) {
+	if err == nil {
+		return
+	}
+	o.reportError(fmt.Errorf("writing notify-json record: %w", err))
+}
+
+func (o *Output) reportError(err error) {
+	select {
+	case o.errorChan <- err:
+	default:
+	}
+}
+
+func (o *Output) Stop() error {
+	if o.done == nil {
+		return nil
+	}
+	o.stopOnce.Do(func() { close(o.done) })
+	if o.engine != nil {
+		o.engine.Stop()
+	}
+	o.wg.Wait()
+	if o.errorChan != nil {
+		close(o.errorChan)
+	}
+	o.eventChan = nil
+	o.errorChan = nil
+	o.done = nil
+	return nil
+}
+
+func (o *Output) ErrorChan() <-chan error        { return o.errorChan }
+func (o *Output) InputChan() chan<- event.Event  { return o.eventChan }
+func (o *Output) OutputChan() <-chan event.Event { return nil }

--- a/output/notifyjson/notifyjson_test.go
+++ b/output/notifyjson/notifyjson_test.go
@@ -141,6 +141,22 @@ func TestOutputReportsStaleAndRecovery(t *testing.T) {
 	require.NoError(t, o.Stop())
 }
 
+func TestOutputReportsStaleBeforeFirstEvent(t *testing.T) {
+	var output lockedBuffer
+	o := New(
+		WithConfigPath(writeTestConfig(t)),
+		WithWriter(&output),
+		WithStaleAfter(25*time.Millisecond),
+	)
+	require.NoError(t, o.Start())
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), `"status":"stale"`)
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, o.Stop())
+	require.Equal(t, 1, strings.Count(output.String(), `"status":"stale"`))
+	require.NotContains(t, output.String(), `"kind":"notification"`)
+}
+
 func TestOutputNormalizesNativeEventBeforeRendering(t *testing.T) {
 	var output lockedBuffer
 	o := New(

--- a/output/notifyjson/notifyjson_test.go
+++ b/output/notifyjson/notifyjson_test.go
@@ -1,0 +1,240 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notifyjson
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/blinklabs-io/adder/event"
+	"github.com/blinklabs-io/adder/tray/setup"
+	"github.com/stretchr/testify/require"
+)
+
+type lockedBuffer struct {
+	mu sync.Mutex
+	b  bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(data []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.Write(data)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.b.String()
+}
+
+func writeTestConfig(
+	t *testing.T,
+	mutate ...func(*setup.NotificationConfig),
+) string {
+	t.Helper()
+	cfg := setup.DefaultNotificationConfig()
+	cfg.Monitor.Everything = true
+	cfg.RateLimit.Max = -1
+	for _, fn := range mutate {
+		fn(&cfg)
+	}
+	data, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	path := filepath.Join(t.TempDir(), "notifications.json")
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	return path
+}
+
+func testTransaction() event.Event {
+	return event.Event{
+		Type:      event.TypeTransaction,
+		Timestamp: time.Now(),
+		Context: map[string]any{
+			"transactionHash": "0123456789abcdef",
+		},
+		Payload: map[string]any{},
+	}
+}
+
+func testNativeBlock() event.Event {
+	return event.Event{
+		Type:      event.TypeBlock,
+		Timestamp: time.Now(),
+		Context: event.BlockContext{
+			BlockNumber: 13_335_000,
+		},
+		Payload: event.BlockEvent{
+			BlockHash: "84ee913d2d3aaaaabbbb255af401",
+		},
+	}
+}
+
+type nativeTestOutput struct {
+	Address string `json:"address"`
+	Amount  uint64 `json:"amount"`
+}
+
+type nativeTestTransaction struct {
+	Outputs []nativeTestOutput `json:"outputs"`
+}
+
+func TestOutputEmitsStatusAndMatchedNotification(t *testing.T) {
+	var output lockedBuffer
+	o := New(
+		WithConfigPath(writeTestConfig(t)),
+		WithWriter(&output),
+		WithStaleAfter(time.Hour),
+	)
+	require.NoError(t, o.Start())
+	o.InputChan() <- testTransaction()
+	require.Eventually(t, func() bool {
+		text := output.String()
+		return strings.Contains(text, `"status":"connected"`) &&
+			strings.Contains(text, `"kind":"notification"`) &&
+			strings.Contains(text, `"ruleId":"everything-tx"`)
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, o.Stop())
+
+	for _, line := range strings.Split(strings.TrimSpace(output.String()), "\n") {
+		var record map[string]any
+		require.NoError(t, json.Unmarshal([]byte(line), &record), line)
+		require.Equal(t, float64(schemaVersion), record["schemaVersion"])
+	}
+}
+
+func TestOutputReportsStaleAndRecovery(t *testing.T) {
+	var output lockedBuffer
+	o := New(
+		WithConfigPath(writeTestConfig(t)),
+		WithWriter(&output),
+		WithStaleAfter(25*time.Millisecond),
+	)
+	require.NoError(t, o.Start())
+	o.InputChan() <- testTransaction()
+	require.Eventually(t, func() bool {
+		return strings.Contains(output.String(), `"status":"stale"`)
+	}, 2*time.Second, 10*time.Millisecond)
+	o.InputChan() <- testTransaction()
+	require.Eventually(t, func() bool {
+		return strings.Count(output.String(), `"status":"connected"`) == 2 &&
+			strings.Contains(output.String(), `Reconnected to mainnet`)
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, o.Stop())
+}
+
+func TestOutputNormalizesNativeEventBeforeRendering(t *testing.T) {
+	var output lockedBuffer
+	o := New(
+		WithConfigPath(writeTestConfig(t)),
+		WithWriter(&output),
+		WithStaleAfter(time.Hour),
+	)
+	require.NoError(t, o.Start())
+	o.InputChan() <- testNativeBlock()
+	require.Eventually(t, func() bool {
+		return strings.Contains(
+			output.String(),
+			`"body":"Block #13335000 (84ee913d...255af401) minted."`,
+		)
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NotContains(t, output.String(), "{{")
+	require.NoError(t, o.Stop())
+}
+
+func TestNormalizeEventUsesJSONFieldNames(t *testing.T) {
+	normalized, err := normalizeEvent(testNativeBlock())
+	require.NoError(t, err)
+	context, ok := normalized.Context.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t, float64(13_335_000), context["blockNumber"])
+	payload, ok := normalized.Payload.(map[string]any)
+	require.True(t, ok)
+	require.Equal(t,
+		"84ee913d2d3aaaaabbbb255af401",
+		payload["blockHash"],
+	)
+}
+
+func TestNormalizeEventPreservesJSONShapedEvents(t *testing.T) {
+	evt := testTransaction()
+	normalized, err := normalizeEvent(evt)
+	require.NoError(t, err)
+	require.Equal(t, evt, normalized)
+}
+
+func BenchmarkNormalizeEvent(b *testing.B) {
+	for _, test := range []struct {
+		name  string
+		event event.Event
+	}{
+		{name: "native", event: testNativeBlock()},
+		{name: "json-shaped", event: testTransaction()},
+	} {
+		b.Run(test.name, func(b *testing.B) {
+			for b.Loop() {
+				if _, err := normalizeEvent(test.event); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}
+
+func TestOutputNormalizesNativeEventBeforeTargetMatching(t *testing.T) {
+	var output lockedBuffer
+	configPath := writeTestConfig(t, func(cfg *setup.NotificationConfig) {
+		cfg.Monitor.Everything = false
+		cfg.Monitor.Wallets = []string{"addr1watched"}
+	})
+	o := New(
+		WithConfigPath(configPath),
+		WithWriter(&output),
+		WithStaleAfter(time.Hour),
+	)
+	require.NoError(t, o.Start())
+	o.InputChan() <- event.Event{
+		Type: event.TypeTransaction,
+		Context: event.TransactionContext{
+			TransactionHash: "0123456789abcdef",
+		},
+		Payload: nativeTestTransaction{Outputs: []nativeTestOutput{{
+			Address: "addr1watched",
+			Amount:  5_000_000,
+		}}},
+	}
+	require.Eventually(t, func() bool {
+		return strings.Contains(
+			output.String(),
+			`"ruleId":"wallet-in"`,
+		) && strings.Contains(
+			output.String(),
+			`"body":"Received 5 ADA at addr1watched."`,
+		)
+	}, 2*time.Second, 10*time.Millisecond)
+	require.NoError(t, o.Stop())
+}
+
+func TestOutputRequiresConfig(t *testing.T) {
+	o := New()
+	require.ErrorContains(t, o.Start(), "config path")
+	require.NoError(t, o.Stop())
+}

--- a/output/notifyjson/notifyjson_test.go
+++ b/output/notifyjson/notifyjson_test.go
@@ -157,6 +157,30 @@ func TestOutputReportsStaleBeforeFirstEvent(t *testing.T) {
 	require.NotContains(t, output.String(), `"kind":"notification"`)
 }
 
+func TestOutputReloadsStaleThresholdOnRestart(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "notifications.json")
+	writeConfig := func(seconds int) {
+		cfg := setup.DefaultNotificationConfig()
+		cfg.Monitor.Everything = true
+		cfg.ConnectionStaleSeconds = seconds
+		data, err := json.Marshal(cfg)
+		require.NoError(t, err)
+		require.NoError(t, os.WriteFile(path, data, 0o600))
+	}
+
+	var output lockedBuffer
+	o := New(WithConfigPath(path), WithWriter(&output))
+	t.Cleanup(func() { _ = o.Stop() })
+	writeConfig(30)
+	require.NoError(t, o.Start())
+	require.Equal(t, 30*time.Second, o.staleAfter)
+	require.NoError(t, o.Stop())
+	writeConfig(60)
+	require.NoError(t, o.Start())
+	require.Equal(t, 60*time.Second, o.staleAfter)
+	require.NoError(t, o.Stop())
+}
+
 func TestOutputNormalizesNativeEventBeforeRendering(t *testing.T) {
 	var output lockedBuffer
 	o := New(

--- a/output/notifyjson/options.go
+++ b/output/notifyjson/options.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package output
+package notifyjson
 
-// We import the various plugins that we want to be auto-registered
 import (
-	_ "github.com/blinklabs-io/adder/output/log"
-	_ "github.com/blinklabs-io/adder/output/notify"
-	_ "github.com/blinklabs-io/adder/output/notifyjson"
-	_ "github.com/blinklabs-io/adder/output/push"
-	_ "github.com/blinklabs-io/adder/output/telegram"
-	_ "github.com/blinklabs-io/adder/output/webhook"
+	"io"
+	"time"
 )
+
+type Option func(*Output)
+
+func WithConfigPath(path string) Option {
+	return func(o *Output) { o.configPath = path }
+}
+
+func WithWriter(w io.Writer) Option {
+	return func(o *Output) {
+		if w != nil {
+			o.writer = w
+		}
+	}
+}
+
+func WithStaleAfter(d time.Duration) Option {
+	return func(o *Output) { o.staleAfter = d }
+}

--- a/output/notifyjson/options.go
+++ b/output/notifyjson/options.go
@@ -34,5 +34,5 @@ func WithWriter(w io.Writer) Option {
 }
 
 func WithStaleAfter(d time.Duration) Option {
-	return func(o *Output) { o.staleAfter = d }
+	return func(o *Output) { o.staleAfterOverride = d }
 }

--- a/output/notifyjson/plugin.go
+++ b/output/notifyjson/plugin.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package notifyjson
+
+import "github.com/blinklabs-io/adder/plugin"
+
+var cmdlineOptions struct {
+	config string
+}
+
+func init() {
+	plugin.Register(plugin.PluginEntry{
+		Type:               plugin.PluginTypeOutput,
+		Name:               "notify-json",
+		Description:        "emit target-aware desktop notification requests as NDJSON",
+		NewFromOptionsFunc: NewFromCmdlineOptions,
+		Options: []plugin.PluginOption{
+			{
+				Name:         "config",
+				Type:         plugin.PluginOptionTypeString,
+				Description:  "path to a versioned notification JSON configuration",
+				DefaultValue: "",
+				Dest:         &cmdlineOptions.config,
+			},
+		},
+	})
+}
+
+func NewFromCmdlineOptions() plugin.Plugin {
+	return New(WithConfigPath(cmdlineOptions.config))
+}

--- a/tray/app.go
+++ b/tray/app.go
@@ -641,7 +641,7 @@ func (a *App) setupTray() {
 	eng.Start()
 	go notifications.Dispatch(
 		eng.Requests(),
-		a.fyneApp,
+		fyneNotifier{app: a.fyneApp},
 		eng.CurrentEpoch,
 		eng.RecordDrop,
 		a.addRecentAlert,

--- a/tray/fyne_notifier.go
+++ b/tray/fyne_notifier.go
@@ -1,4 +1,4 @@
-// Copyright 2023 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package output
+package tray
 
-// We import the various plugins that we want to be auto-registered
-import (
-	_ "github.com/blinklabs-io/adder/output/log"
-	_ "github.com/blinklabs-io/adder/output/notify"
-	_ "github.com/blinklabs-io/adder/output/notifyjson"
-	_ "github.com/blinklabs-io/adder/output/push"
-	_ "github.com/blinklabs-io/adder/output/telegram"
-	_ "github.com/blinklabs-io/adder/output/webhook"
-)
+import "fyne.io/fyne/v2"
+
+type fyneNotifier struct {
+	app fyne.App
+}
+
+func (n fyneNotifier) SendNotification(title, body string) {
+	n.app.SendNotification(fyne.NewNotification(title, body))
+}

--- a/tray/notifications/notify.go
+++ b/tray/notifications/notify.go
@@ -16,17 +16,12 @@ package notifications
 
 import (
 	"log/slog"
-
-	"fyne.io/fyne/v2"
 )
 
-// Notifier is the minimal surface of fyne.App needed to dispatch a
-// desktop notification. fyne.App satisfies it directly; tests inject a
-// fake via fyne.io/fyne/v2/test's test.NewApp (which records sent
-// notifications for test.AssertNotificationSent). This is the only file
-// in the notifications package permitted to import fyne.
+// Notifier is the UI-neutral surface needed to dispatch a desktop
+// notification. Desktop frontends adapt their native notification API to it.
 type Notifier interface {
-	SendNotification(*fyne.Notification)
+	SendNotification(title, body string)
 }
 
 // Dispatch reads Requests from reqs and sends each as a native desktop
@@ -65,7 +60,7 @@ func Dispatch(
 			"title", title,
 			"batched", req.Batched,
 			"count", req.Count)
-		n.SendNotification(fyne.NewNotification(title, req.Body))
+		n.SendNotification(title, req.Body)
 		for _, fn := range onDelivered {
 			if fn != nil {
 				fn(req)

--- a/tray/notifications/notify_test.go
+++ b/tray/notifications/notify_test.go
@@ -20,8 +20,6 @@ import (
 	"testing"
 	"time"
 
-	"fyne.io/fyne/v2"
-	"fyne.io/fyne/v2/test"
 	"github.com/blinklabs-io/adder/event"
 	"github.com/stretchr/testify/require"
 )
@@ -31,61 +29,56 @@ import (
 // can be observed safely from the test goroutine under -race.
 type recordingNotifier struct {
 	mu   sync.Mutex
-	last *fyne.Notification
+	last *recordedNotification
 }
 
-func (r *recordingNotifier) SendNotification(n *fyne.Notification) {
+type recordedNotification struct {
+	Title   string
+	Content string
+}
+
+func (r *recordingNotifier) SendNotification(title, body string) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	r.last = n
+	r.last = &recordedNotification{Title: title, Content: body}
 }
 
-func (r *recordingNotifier) lastSent() *fyne.Notification {
+func (r *recordingNotifier) lastSent() *recordedNotification {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.last
 }
 
 func TestDispatch_SendsNotification(t *testing.T) {
-	app := test.NewApp()
+	n := &recordingNotifier{}
 	reqs := make(chan Request, 1)
-
-	test.AssertNotificationSent(
-		t,
-		fyne.NewNotification("💸 Incoming Transaction", "Received 5 ADA at a"),
-		func() {
-			reqs <- Request{
-				RuleID: "wallet-in-0",
-				Title:  "💸 Incoming Transaction",
-				Body:   "Received 5 ADA at a",
-			}
-			close(reqs)
-			Dispatch(reqs, app, nil, nil)
-		},
-	)
+	reqs <- Request{
+		RuleID: "wallet-in-0",
+		Title:  "💸 Incoming Transaction",
+		Body:   "Received 5 ADA at a",
+	}
+	close(reqs)
+	Dispatch(reqs, n, nil, nil)
+	require.Equal(t, &recordedNotification{
+		Title: "💸 Incoming Transaction", Content: "Received 5 ADA at a",
+	}, n.lastSent())
 }
 
 func TestDispatch_EmptyTitleFallsBackToAdder(t *testing.T) {
-	app := test.NewApp()
+	n := &recordingNotifier{}
 	reqs := make(chan Request, 1)
-
-	test.AssertNotificationSent(
-		t,
-		fyne.NewNotification("Adder", "body"),
-		func() {
-			reqs <- Request{Body: "body"}
-			close(reqs)
-			Dispatch(reqs, app, nil, nil)
-		},
-	)
+	reqs <- Request{Body: "body"}
+	close(reqs)
+	Dispatch(reqs, n, nil, nil)
+	require.Equal(t, &recordedNotification{Title: "Adder", Content: "body"}, n.lastSent())
 }
 
 func TestDispatch_StopsWhenChannelClosed(t *testing.T) {
-	app := test.NewApp()
+	n := &recordingNotifier{}
 	reqs := make(chan Request)
 	done := make(chan struct{})
 	go func() {
-		Dispatch(reqs, app, nil, nil)
+		Dispatch(reqs, n, nil, nil)
 		close(done)
 	}()
 	close(reqs)

--- a/tray/notifications/render_test.go
+++ b/tray/notifications/render_test.go
@@ -141,7 +141,7 @@ func TestRenderTemplates_RealPhrasings(t *testing.T) {
 				"(84ee913d...255af401).",
 		},
 		{
-			name: "drep vote",
+			name: "drep vote identifies action with zero index",
 			tmpl: tmplGovVote,
 			evt: event.Event{
 				Type: EventTypeGovernance,
@@ -150,12 +150,14 @@ func TestRenderTemplates_RealPhrasings(t *testing.T) {
 						map[string]any{
 							"voterId":        "drep1abc0123456789wxyz",
 							"vote":           "Yes",
-							"govActionIndex": float64(42),
+							"govActionTxId":  "0123456789abcdef0123456789abcdeffedcba9876543210fedcba98",
+							"govActionIndex": float64(0),
 						},
 					},
 				},
 			},
-			want: "DRep drep1abc…wxyz voted Yes on proposal #42.",
+			want: "DRep drep1abc…wxyz voted Yes on action " +
+				"01234567...fedcba98#0.",
 		},
 		{
 			// Regression: an event carrying several votes must render
@@ -170,17 +172,20 @@ func TestRenderTemplates_RealPhrasings(t *testing.T) {
 						map[string]any{
 							"voterId":        "drep1otherCCCCDDDDzzzz",
 							"vote":           "No",
+							"govActionTxId":  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 							"govActionIndex": float64(7),
 						},
 						map[string]any{
 							"voterId":        "drep1followedAAAAwxyz",
 							"vote":           "Yes",
+							"govActionTxId":  "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
 							"govActionIndex": float64(42),
 						},
 					},
 				},
 			},
-			want: "DRep drep1fol…wxyz voted Yes on proposal #42.",
+			want: "DRep drep1fol…wxyz voted Yes on action " +
+				"bbbbbbbb...bbbbbbbb#42.",
 		},
 	}
 	for _, tt := range tests {
@@ -331,7 +336,7 @@ func TestRenderTemplates_MissingFields(t *testing.T) {
 				Type:    EventTypeGovernance,
 				Payload: map[string]any{},
 			},
-			want: "DRep  voted  on proposal #.",
+			want: "DRep  voted  on action #.",
 		},
 	}
 	for _, tt := range tests {

--- a/tray/notifications/rules.go
+++ b/tray/notifications/rules.go
@@ -79,7 +79,8 @@ const (
 	tmplGovVote = "DRep " +
 		"{{trunc (field \"voterId\" (voteFor .payload.votingProcedures .params))}} " +
 		"voted {{field \"vote\" (voteFor .payload.votingProcedures .params)}} " +
-		"on proposal " +
+		"on action " +
+		"{{truncHash (field \"govActionTxId\" (voteFor .payload.votingProcedures .params))}}" +
 		"#{{field \"govActionIndex\" (voteFor .payload.votingProcedures .params)}}."
 	tmplGovProposal   = "New governance proposal detected."
 	tmplGovReg        = "A registration change was detected."

--- a/tray/setup/notification_config.go
+++ b/tray/setup/notification_config.go
@@ -1,0 +1,305 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+const (
+	NotificationConfigSchemaVersion = 1
+	DefaultConnectionStaleSeconds   = 90
+
+	AlertIncomingTransactions = "incomingTransactions"
+	AlertOutgoingTransactions = "outgoingTransactions"
+	AlertTokenTransfers       = "tokenTransfers"
+	AlertBlocksMinted         = "blocksMinted"
+	AlertChainRollbacks       = "chainRollbacks"
+	AlertPoolParameterChanges = "poolParameterChanges"
+	AlertGovernanceProposals  = "governanceProposals"
+	AlertVotesCast            = "votesCast"
+	AlertRegistrationChanges  = "registrationChanges"
+	AlertAssetActivity        = "assetActivity"
+	AlertPolicyActivity       = "policyActivity"
+	AlertConnectionIssues     = "connectionIssues"
+)
+
+// NotificationConfig is the UI-neutral configuration consumed by headless
+// notification outputs. It deliberately uses stable machine keys rather than
+// the tray's user-facing labels so non-Go clients can safely persist it.
+type NotificationConfig struct {
+	SchemaVersion          int                       `json:"schemaVersion"`
+	Network                NotificationNetworkConfig `json:"network"`
+	Monitor                NotificationMonitorConfig `json:"monitor"`
+	Alerts                 map[string]bool           `json:"alerts"`
+	RateLimit              NotificationRateConfig    `json:"rateLimit"`
+	ConnectionStaleSeconds int                       `json:"connectionStaleSeconds"`
+}
+
+type NotificationNetworkConfig struct {
+	Name          string `json:"name"`
+	CustomAddress string `json:"customAddress,omitempty"`
+	CustomPort    uint   `json:"customPort,omitempty"`
+}
+
+type NotificationMonitorConfig struct {
+	Everything  bool              `json:"everything"`
+	Wallets     []string          `json:"wallets,omitempty"`
+	DReps       []string          `json:"dreps,omitempty"`
+	Pools       []string          `json:"pools,omitempty"`
+	Assets      []string          `json:"assets,omitempty"`
+	Policies    []string          `json:"policies,omitempty"`
+	DRepMatch   AdvancedMatchMode `json:"drepMatch,omitempty"`
+	PoolMatch   AdvancedMatchMode `json:"poolMatch,omitempty"`
+	AssetMatch  AdvancedMatchMode `json:"assetMatch,omitempty"`
+	PolicyMatch AdvancedMatchMode `json:"policyMatch,omitempty"`
+}
+
+type NotificationRateConfig struct {
+	Max           int `json:"max"`
+	WindowSeconds int `json:"windowSeconds"`
+}
+
+// ValidationIssue is stable JSON output for configuration frontends.
+type ValidationIssue struct {
+	Field   string `json:"field"`
+	Message string `json:"message"`
+}
+
+func DefaultNotificationConfig() NotificationConfig {
+	return NotificationConfig{
+		SchemaVersion: NotificationConfigSchemaVersion,
+		Network: NotificationNetworkConfig{
+			Name: "mainnet",
+		},
+		Monitor: NotificationMonitorConfig{},
+		Alerts: map[string]bool{
+			AlertIncomingTransactions: true,
+			AlertOutgoingTransactions: true,
+			AlertTokenTransfers:       true,
+			AlertBlocksMinted:         true,
+			AlertChainRollbacks:       true,
+			AlertPoolParameterChanges: true,
+			AlertGovernanceProposals:  true,
+			AlertVotesCast:            true,
+			AlertRegistrationChanges:  true,
+			AlertAssetActivity:        true,
+			AlertPolicyActivity:       true,
+			AlertConnectionIssues:     true,
+		},
+		RateLimit: NotificationRateConfig{
+			Max:           DefaultNotifyRateLimit,
+			WindowSeconds: int(DefaultNotifyRateWindow / time.Second),
+		},
+		ConnectionStaleSeconds: DefaultConnectionStaleSeconds,
+	}
+}
+
+func ReadNotificationConfig(path string) (NotificationConfig, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return NotificationConfig{}, fmt.Errorf("reading notification config: %w", err)
+	}
+	defer f.Close()
+	return DecodeNotificationConfig(f)
+}
+
+func DecodeNotificationConfig(r io.Reader) (NotificationConfig, error) {
+	var cfg NotificationConfig
+	decoder := json.NewDecoder(r)
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return cfg, fmt.Errorf("parsing notification config: %w", err)
+	}
+	if err := decoder.Decode(&struct{}{}); !errors.Is(err, io.EOF) {
+		if err == nil {
+			err = errors.New("multiple JSON values")
+		}
+		return cfg, fmt.Errorf("parsing notification config: %w", err)
+	}
+	cfg.normalize()
+	if issues := cfg.ValidationIssues(); len(issues) > 0 {
+		return cfg, ValidationIssuesError{Issues: issues}
+	}
+	return cfg, nil
+}
+
+func (c *NotificationConfig) normalize() {
+	c.Network.Name = strings.TrimSpace(c.Network.Name)
+	c.Network.CustomAddress = strings.TrimSpace(c.Network.CustomAddress)
+	c.Monitor.DRepMatch = AdvancedMatchMode(strings.TrimSpace(string(c.Monitor.DRepMatch)))
+	c.Monitor.PoolMatch = AdvancedMatchMode(strings.TrimSpace(string(c.Monitor.PoolMatch)))
+	c.Monitor.AssetMatch = AdvancedMatchMode(strings.TrimSpace(string(c.Monitor.AssetMatch)))
+	c.Monitor.PolicyMatch = AdvancedMatchMode(strings.TrimSpace(string(c.Monitor.PolicyMatch)))
+	trimAll := func(values []string) {
+		for i := range values {
+			values[i] = strings.TrimSpace(values[i])
+		}
+	}
+	trimAll(c.Monitor.Wallets)
+	trimAll(c.Monitor.DReps)
+	trimAll(c.Monitor.Pools)
+	trimAll(c.Monitor.Assets)
+	trimAll(c.Monitor.Policies)
+}
+
+type ValidationIssuesError struct {
+	Issues []ValidationIssue
+}
+
+func (e ValidationIssuesError) Error() string {
+	parts := make([]string, 0, len(e.Issues))
+	for _, issue := range e.Issues {
+		parts = append(parts, issue.Field+": "+issue.Message)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func (c NotificationConfig) ValidationIssues() []ValidationIssue {
+	var issues []ValidationIssue
+	add := func(field, message string) {
+		issues = append(issues, ValidationIssue{Field: field, Message: message})
+	}
+
+	if c.SchemaVersion != NotificationConfigSchemaVersion {
+		add("schemaVersion", fmt.Sprintf("must be %d", NotificationConfigSchemaVersion))
+	}
+	switch c.Network.Name {
+	case "mainnet", "preprod", "preview":
+	default:
+		add("network.name", "must be mainnet, preprod, or preview")
+	}
+	if strings.TrimSpace(c.Network.CustomAddress) == "" && c.Network.CustomPort != 0 {
+		add("network.customAddress", "must be set when customPort is set")
+	}
+	if strings.TrimSpace(c.Network.CustomAddress) != "" &&
+		(c.Network.CustomPort == 0 || c.Network.CustomPort > 65535) {
+		add("network.customPort", "must be between 1 and 65535 when using a custom node")
+	}
+
+	validateTargets := func(field string, values []string, validate func(string) error) {
+		seen := make(map[string]struct{}, len(values))
+		for i, value := range values {
+			value = strings.TrimSpace(value)
+			itemField := fmt.Sprintf("monitor.%s[%d]", field, i)
+			if err := validate(value); err != nil {
+				add(itemField, err.Error())
+			}
+			key := strings.ToLower(value)
+			if _, ok := seen[key]; ok {
+				add(itemField, "duplicate target")
+			}
+			seen[key] = struct{}{}
+		}
+	}
+	validateTargets("wallets", c.Monitor.Wallets, ValidateWalletAddr)
+	validateTargets("dreps", c.Monitor.DReps, ValidateDRepID)
+	validateTargets("pools", c.Monitor.Pools, ValidatePoolID)
+	validateTargets("assets", c.Monitor.Assets, ValidateAssetFingerprint)
+	validateTargets("policies", c.Monitor.Policies, ValidatePolicyID)
+
+	if !c.Monitor.Everything && len(c.Monitor.Wallets)+len(c.Monitor.DReps)+
+		len(c.Monitor.Pools)+len(c.Monitor.Assets)+len(c.Monitor.Policies) == 0 {
+		add("monitor", "configure at least one target or enable everything")
+	}
+	validateMatch := func(field string, mode AdvancedMatchMode) {
+		if mode != "" && mode != AdvancedMatchAny && mode != AdvancedMatchAll {
+			add(field, "must be any or all")
+		}
+	}
+	validateMatch("monitor.drepMatch", c.Monitor.DRepMatch)
+	validateMatch("monitor.poolMatch", c.Monitor.PoolMatch)
+	validateMatch("monitor.assetMatch", c.Monitor.AssetMatch)
+	validateMatch("monitor.policyMatch", c.Monitor.PolicyMatch)
+
+	knownAlerts := map[string]struct{}{
+		AlertIncomingTransactions: {}, AlertOutgoingTransactions: {},
+		AlertTokenTransfers: {}, AlertBlocksMinted: {}, AlertChainRollbacks: {},
+		AlertPoolParameterChanges: {}, AlertGovernanceProposals: {},
+		AlertVotesCast: {}, AlertRegistrationChanges: {}, AlertAssetActivity: {},
+		AlertPolicyActivity: {}, AlertConnectionIssues: {},
+	}
+	anyAlert := false
+	for key, enabled := range c.Alerts {
+		if _, ok := knownAlerts[key]; !ok {
+			add("alerts."+key, "unknown alert category")
+		}
+		anyAlert = anyAlert || enabled
+	}
+	if !anyAlert {
+		add("alerts", "enable at least one alert category")
+	}
+	if c.RateLimit.Max < -1 {
+		add("rateLimit.max", "must be -1 (disabled) or zero or greater")
+	}
+	if c.RateLimit.WindowSeconds <= 0 {
+		add("rateLimit.windowSeconds", "must be greater than zero")
+	}
+	if c.ConnectionStaleSeconds < 30 || c.ConnectionStaleSeconds > 3600 {
+		add("connectionStaleSeconds", "must be between 30 and 3600")
+	}
+	return issues
+}
+
+func (c NotificationConfig) SetupPlan() SetupPlan {
+	prefs := NotificationPrefs{
+		NotifyPrefIncomingTx:       c.Alerts[AlertIncomingTransactions],
+		NotifyPrefOutgoingTx:       c.Alerts[AlertOutgoingTransactions],
+		NotifyPrefTokenTransfers:   c.Alerts[AlertTokenTransfers],
+		NotifyPrefBlocksMinted:     c.Alerts[AlertBlocksMinted],
+		NotifyPrefChainRollbacks:   c.Alerts[AlertChainRollbacks],
+		NotifyPrefPoolParams:       c.Alerts[AlertPoolParameterChanges],
+		NotifyPrefGovProposals:     c.Alerts[AlertGovernanceProposals],
+		NotifyPrefVotesCast:        c.Alerts[AlertVotesCast],
+		NotifyPrefRegChanges:       c.Alerts[AlertRegistrationChanges],
+		NotifyPrefAssetActivity:    c.Alerts[AlertAssetActivity],
+		NotifyPrefPolicyActivity:   c.Alerts[AlertPolicyActivity],
+		NotifyPrefConnectionIssues: c.Alerts[AlertConnectionIssues],
+	}
+	return SetupPlan{
+		Network: NetworkConfig{
+			Name:          c.Network.Name,
+			CustomAddress: c.Network.CustomAddress,
+			CustomPort:    c.Network.CustomPort,
+		},
+		Filter: FilterConfig{
+			MonitorEverything: c.Monitor.Everything,
+			Wallets:           append([]string(nil), c.Monitor.Wallets...),
+			DReps:             append([]string(nil), c.Monitor.DReps...),
+			Pools:             append([]string(nil), c.Monitor.Pools...),
+			Assets:            append([]string(nil), c.Monitor.Assets...),
+			Policies:          append([]string(nil), c.Monitor.Policies...),
+			DRepMatch:         c.Monitor.DRepMatch,
+			PoolMatch:         c.Monitor.PoolMatch,
+			AssetMatch:        c.Monitor.AssetMatch,
+			PolicyMatch:       c.Monitor.PolicyMatch,
+		},
+		Notify: prefs,
+		App: AppConfig{
+			NotifyRateLimit:  c.RateLimit.Max,
+			NotifyRateWindow: time.Duration(c.RateLimit.WindowSeconds) * time.Second,
+		},
+	}
+}
+
+func (c NotificationConfig) NetworkLabel() string {
+	return c.Network.Name
+}

--- a/tray/setup/notification_config.go
+++ b/tray/setup/notification_config.go
@@ -135,14 +135,14 @@ func DecodeNotificationConfig(r io.Reader) (NotificationConfig, error) {
 		}
 		return cfg, fmt.Errorf("parsing notification config: %w", err)
 	}
-	cfg.normalize()
+	normalizeNotificationConfig(&cfg)
 	if issues := cfg.ValidationIssues(); len(issues) > 0 {
 		return cfg, ValidationIssuesError{Issues: issues}
 	}
 	return cfg, nil
 }
 
-func (c *NotificationConfig) normalize() {
+func normalizeNotificationConfig(c *NotificationConfig) {
 	c.Network.Name = strings.TrimSpace(c.Network.Name)
 	c.Network.CustomAddress = strings.TrimSpace(c.Network.CustomAddress)
 	c.Monitor.DRepMatch = AdvancedMatchMode(strings.TrimSpace(string(c.Monitor.DRepMatch)))

--- a/tray/setup/notification_config_test.go
+++ b/tray/setup/notification_config_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package setup
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func validNotificationConfig() NotificationConfig {
+	cfg := DefaultNotificationConfig()
+	cfg.Monitor.Wallets = []string{"addr1test"}
+	return cfg
+}
+
+func TestNotificationConfigRoundTrip(t *testing.T) {
+	cfg, err := DecodeNotificationConfig(strings.NewReader(`{
+  "schemaVersion": 1,
+  "network": {"name": "preview"},
+  "monitor": {
+    "everything": false,
+    "wallets": ["addr_test1example"],
+    "drepMatch": "any",
+    "poolMatch": "any",
+    "assetMatch": "any",
+    "policyMatch": "any"
+  },
+  "alerts": {"incomingTransactions": true},
+  "rateLimit": {"max": 2, "windowSeconds": 10},
+  "connectionStaleSeconds": 90
+}`))
+	require.NoError(t, err)
+	require.Equal(t, "preview", cfg.Network.Name)
+	require.Equal(t, []string{"addr_test1example"}, cfg.Monitor.Wallets)
+	plan := cfg.SetupPlan()
+	require.True(t, plan.Notify[NotifyPrefIncomingTx])
+	require.Equal(t, 2, plan.App.NotifyRateLimit)
+}
+
+func TestNotificationConfigNormalizesTextValues(t *testing.T) {
+	cfg, err := DecodeNotificationConfig(strings.NewReader(`{
+  "schemaVersion": 1,
+  "network": {"name":" mainnet ","customAddress":" node.example ","customPort":3001},
+  "monitor": {
+    "wallets":[" addr1test "],"dreps":[],"pools":[],"assets":[],"policies":[],
+    "drepMatch":" any ","poolMatch":"","assetMatch":"","policyMatch":""
+  },
+  "alerts": {"incomingTransactions":true},
+  "rateLimit": {"max":1,"windowSeconds":5},
+  "connectionStaleSeconds":90
+}`))
+	require.NoError(t, err)
+	require.Equal(t, "mainnet", cfg.Network.Name)
+	require.Equal(t, "node.example", cfg.Network.CustomAddress)
+	require.Equal(t, []string{"addr1test"}, cfg.Monitor.Wallets)
+	require.Equal(t, AdvancedMatchAny, cfg.Monitor.DRepMatch)
+
+	plan := cfg.SetupPlan()
+	require.Equal(t, "node.example", plan.Network.CustomAddress)
+	require.Equal(t, []string{"addr1test"}, plan.Filter.Wallets)
+	require.Equal(t, "mainnet", cfg.NetworkLabel())
+}
+
+func TestNotificationConfigRejectsUnknownFields(t *testing.T) {
+	_, err := DecodeNotificationConfig(strings.NewReader(`{"schemaVersion":1,"surprise":true}`))
+	require.ErrorContains(t, err, "unknown field")
+}
+
+func TestNotificationConfigValidationIssues(t *testing.T) {
+	cfg := validNotificationConfig()
+	cfg.SchemaVersion = 2
+	cfg.Network.Name = "custom"
+	cfg.Monitor.Wallets = append(cfg.Monitor.Wallets, cfg.Monitor.Wallets[0])
+	cfg.RateLimit.WindowSeconds = 0
+	cfg.ConnectionStaleSeconds = 10
+	issues := cfg.ValidationIssues()
+	require.NotEmpty(t, issues)
+	fields := make(map[string]bool)
+	for _, issue := range issues {
+		fields[issue.Field] = true
+	}
+	require.True(t, fields["schemaVersion"])
+	require.True(t, fields["network.name"])
+	require.True(t, fields["monitor.wallets[1]"])
+	require.True(t, fields["rateLimit.windowSeconds"])
+	require.True(t, fields["connectionStaleSeconds"])
+}
+
+func TestNotificationConfigRequiresExplicitScope(t *testing.T) {
+	cfg := DefaultNotificationConfig()
+	_, err := DecodeNotificationConfig(strings.NewReader(mustJSON(t, cfg)))
+	var validationErr ValidationIssuesError
+	require.True(t, errors.As(err, &validationErr))
+	require.Contains(t, validationErr.Error(), "configure at least one target")
+
+	cfg.Monitor.Everything = true
+	_, err = DecodeNotificationConfig(strings.NewReader(mustJSON(t, cfg)))
+	require.NoError(t, err)
+}
+
+func mustJSON(t *testing.T, value any) string {
+	t.Helper()
+	data, err := json.Marshal(value)
+	require.NoError(t, err)
+	return string(data)
+}


### PR DESCRIPTION
## Summary

- add a GUI-free `notify-json` output that emits versioned NDJSON status and notification records
- add a versioned, UI-neutral notification configuration plus `adder notifications validate`
- reuse the tray notification rules and rate limiting while isolating Fyne behind a small adapter
- normalize native event payloads and include the governance action reference in vote notifications
- document the headless integration and stdout/stderr contract

## Motivation

Desktop integrations currently have to either depend on the Fyne tray application or duplicate Adder's notification filtering and rendering logic. This change provides a small headless boundary that lets an external frontend supervise Adder and consume its notifications without linking GUI dependencies or maintaining a second rule engine.

The initial consumer is an Omarchy desktop plugin, but the interface is intentionally generic and contains no Omarchy-specific code.

## Interface

`--output notify-json` reserves stdout for one JSON object per line. Records carry a schema version and are either:

- connection/status updates, or
- rendered notifications with a title and body

Diagnostics remain on stderr so supervisors can parse stdout reliably. Notification configuration has its own schema version, rejects unknown fields and invalid target combinations, and can be checked before startup with:

```console
adder notifications validate --config /path/to/notifications.json
```

## Compatibility

- existing output plugins and command behavior remain unchanged unless `notify-json` is selected
- existing tray notification behavior continues through the new notifier adapter
- the reusable command path does not depend on Fyne, OpenGL, or GLFW
- vote notifications identify actions as a shortened transaction ID plus index, including index `0`

## Testing

- `mise exec go@1.25.7 -- go test -race -timeout 10m ./...`
- `mise exec go@1.25.7 -- go vet ./...`
- `mise exec go@1.25.7 -- make build`
- verified `go list -deps ./cmd/adder` contains no Fyne/OpenGL/GLFW packages
- `git diff --check origin/main..HEAD`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a headless notification output so external supervisors can consume Adder's target-aware notification rules without linking the `fyne` GUI toolkit.

**New Features**
- `--output notify-json` reserves stdout for versioned NDJSON status and notification records, keeping runtime logs on stderr; startup rejects configs whose network or custom node doesn't match the chainsync input.
- Status records now cover startup, connection, staleness, and recovery; a `stale` record is also emitted before the first chain event if none arrive within the timeout.
- `adder notifications validate` checks a versioned JSON config before startup and supports machine-readable output with `--json`.

**Refactors**
- Notification dispatch now uses a UI-neutral `Notifier` interface; `fyne` is wrapped in an adapter, so existing tray behavior is unchanged.
- Vote notifications now identify the governance action as shortened transaction ID plus index, e.g. `01234567...fedcba98#0`, instead of proposal number.
- Notification configuration methods now use consistent pointer receivers.

<sup>Written for commit 2f4d6974992eb15b14b2d273e893d327f9bcd511. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the `notify-json` output option for machine-readable status and notification records.
  * Added versioned JSON notification configuration with alert categories, monitoring targets, rate limits, and connection settings.
  * Added `notifications validate` with human-readable or JSON validation results.
  * Added status reporting for startup, connection, stale connections, recovery, and reconnections.
  * Governance vote notifications now include the related action transaction ID and index.
* **Documentation**
  * Documented notification JSON output, configuration, validation, supported targets, and alert settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->