### PR TITLE
ci: fix docker manifest creation by using buildx imagetools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -109,13 +109,15 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           fetch-depth: '0'
+          persist-credentials: false
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0 https://github.com/actions/setup-go/releases/tag/v7.0.0
         with:
           go-version: 1.26.x
+          cache: false
       - name: Set up MSYS2 MinGW64 for Windows amd64 CGO
         if: matrix.os == 'windows' && matrix.arch == 'amd64' && matrix.tray
         id: msys2-amd64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cc13f75153731901cda3aeead6c28c9fbc4 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: MINGW64
           update: true
@@ -125,7 +127,7 @@ jobs:
       - name: Set up MSYS2 clangarm64 for Windows arm64 CGO
         if: matrix.os == 'windows' && matrix.arch == 'arm64' && matrix.tray
         id: msys2-arm64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cc13f75153731901cda3aeead6c28c9fbc4 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: CLANGARM64
           update: true
@@ -146,12 +148,18 @@ jobs:
       - name: Build binary (Windows)
         if: matrix.os == 'windows'
         shell: pwsh
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          MATRIX_TRAY: ${{ matrix.tray }}
+          MSYS2_AMD64_LOCATION: ${{ steps.msys2-amd64.outputs.msys2-location }}
+          MSYS2_ARM64_LOCATION: ${{ steps.msys2-arm64.outputs.msys2-location }}
         run: |
-          $env:GOOS = "${{ matrix.os }}"
-          $env:GOARCH = "${{ matrix.arch }}"
+          $env:GOOS = $env:MATRIX_OS
+          $env:GOARCH = $env:MATRIX_ARCH
 
-          if ("${{ matrix.arch }}" -eq "amd64") {
-            $msys2Loc = "${{ steps.msys2-amd64.outputs.msys2-location }}"
+          if ($env:MATRIX_ARCH -eq "amd64") {
+            $msys2Loc = $env:MSYS2_AMD64_LOCATION
             $env:CC = "$msys2Loc\mingw64\bin\gcc.exe"
             $env:CXX = "$msys2Loc\mingw64\bin\g++.exe"
 
@@ -159,8 +167,8 @@ jobs:
             & $env:CC --version
           }
 
-          if ("${{ matrix.arch }}" -eq "arm64") {
-            $msys2Loc = "${{ steps.msys2-arm64.outputs.msys2-location }}"
+          if ($env:MATRIX_ARCH -eq "arm64") {
+            $msys2Loc = $env:MSYS2_ARM64_LOCATION
             $env:CC = "$msys2Loc\clangarm64\bin\clang.exe"
             $env:CXX = "$msys2Loc\clangarm64\bin\clang++.exe"
 
@@ -169,7 +177,7 @@ jobs:
           }
 
           make build
-          if ("${{ matrix.tray }}" -eq "true") {
+          if ($env:MATRIX_TRAY -eq "true") {
             make build-tray
           }
       - name: Build binary
@@ -319,6 +327,8 @@ jobs:
       - name: Verify MSI signature (Windows)
         if: ${{ startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' && matrix.tray }}
         shell: pwsh
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           # Locate signtool.exe in the Windows 10/11 SDK install (preinstalled
           # on windows-latest / windows-11-arm runners).
@@ -327,7 +337,7 @@ jobs:
             Write-Error "Windows SDK not found at $sdkRoot"
             exit 1
           }
-          $archDir = if ("${{ matrix.arch }}" -eq "arm64") { "arm64" } else { "x64" }
+          $archDir = if ($env:MATRIX_ARCH -eq "arm64") { "arm64" } else { "x64" }
           $signtool = Get-ChildItem -Path $sdkRoot -Recurse -Filter signtool.exe `
             | Where-Object { $_.FullName -match "\\$archDir\\signtool\.exe$" } `
             | Sort-Object FullName -Descending `
@@ -343,8 +353,8 @@ jobs:
           }
           Write-Host "Using signtool at: $($signtool.FullName)"
 
-          $cleanVersion = "${{ env.RELEASE_TAG }}" -replace '^v', ''
-          $msi = "dist\${{ env.APPLICATION_NAME }}-$cleanVersion-windows-${{ matrix.arch }}.msi"
+          $cleanVersion = $env:RELEASE_TAG -replace '^v', ''
+          $msi = "dist\$env:APPLICATION_NAME-$cleanVersion-windows-$env:MATRIX_ARCH.msi"
           if (-not (Test-Path $msi)) {
             Write-Error "MSI not found at $msi"
             exit 1
@@ -375,6 +385,7 @@ jobs:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
           set -euo pipefail
 
@@ -410,12 +421,12 @@ jobs:
             export VERSION="${RELEASE_TAG#v}"
           fi
 
-          export ARCH="${{ matrix.arch }}"
+          export ARCH="${MATRIX_ARCH}"
           ./packaging/macos/build-pkg.sh
 
           if [ "${IS_RELEASE}" = "true" ]; then
             echo "::group::Verify pkg with spctl (must be accepted + Notarized Developer ID)"
-            PKG_PATH="dist/${APPLICATION_NAME}-${VERSION}-darwin-${{ matrix.arch }}.pkg"
+            PKG_PATH="dist/${APPLICATION_NAME}-${VERSION}-darwin-${MATRIX_ARCH}.pkg"
             spctl_out=$(spctl -a -vv --type install "${PKG_PATH}" 2>&1)
             echo "${spctl_out}"
             echo "${spctl_out}" | grep -q 'accepted'
@@ -426,12 +437,17 @@ jobs:
       - name: Upload MSI release asset (Windows)
         if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' && matrix.tray
         shell: pwsh
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_ID: ${{ needs.create-draft-release.outputs.RELEASE_ID }}
         run: |
-          $cleanVersion = "${{ env.RELEASE_TAG }}" -replace '^v', ''
-          $msiPath  = "dist\${{ env.APPLICATION_NAME }}-$cleanVersion-windows-${{ matrix.arch }}.msi"
+          $cleanVersion = $env:RELEASE_TAG -replace '^v', ''
+          $msiPath  = "dist\$env:APPLICATION_NAME-$cleanVersion-windows-$env:MATRIX_ARCH.msi"
           # Asset name follows the existing convention:
           # adder-<RELEASE_TAG>-<os>-<arch>.<ext> (RELEASE_TAG keeps the leading "v").
-          $assetName = "${{ env.APPLICATION_NAME }}-${{ env.RELEASE_TAG }}-${{ matrix.os }}-${{ matrix.arch }}.msi"
+          $assetName = "$env:APPLICATION_NAME-$env:RELEASE_TAG-$env:MATRIX_OS-$env:MATRIX_ARCH.msi"
           if (-not (Test-Path $msiPath)) {
             Write-Error "MSI not found at $msiPath"
             exit 1
@@ -441,42 +457,54 @@ jobs:
             "Authorization" = "token ${{ secrets.GITHUB_TOKEN }}"
             "Content-Type" = "application/octet-stream"
           }
-          $uploadUrl = "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=$assetName"
+          $uploadUrl = "https://uploads.github.com/repos/$env:GITHUB_REPOSITORY/releases/$env:RELEASE_ID/assets?name=$assetName"
           Invoke-RestMethod -Uri $uploadUrl -Method Post -Headers $headers -InFile $msiPath
 
       - name: Upload release asset (macOS pkg)
         if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'darwin'
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_ID: ${{ needs.create-draft-release.outputs.RELEASE_ID }}
         run: |
           set -euo pipefail
           _version="${RELEASE_TAG#v}"
-          _filename="${APPLICATION_NAME}-${_version}-${{ matrix.os }}-${{ matrix.arch }}.pkg"
+          _filename="${APPLICATION_NAME}-${_version}-${MATRIX_OS}-${MATRIX_ARCH}.pkg"
           _path="dist/${_filename}"
           curl --fail --show-error --silent \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @"${_path}" \
-            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}"
+            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${_filename}"
 
       - name: Upload release asset
         if: startsWith(github.ref, 'refs/tags/') && matrix.os != 'windows' && matrix.os != 'darwin'
+        env:
+          MATRIX_OS: ${{ matrix.os }}
+          MATRIX_ARCH: ${{ matrix.arch }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_ID: ${{ needs.create-draft-release.outputs.RELEASE_ID }}
         run: |
           set -euo pipefail
           # Build from runtime env (not GitHub expression expansion) so a
           # crafted tag name can't inject shell; quote all paths.
-          _filename="${APPLICATION_NAME}-${RELEASE_TAG}-${{ matrix.os }}-${{ matrix.arch }}.tar.gz"
+          _filename="${APPLICATION_NAME}-${RELEASE_TAG}-${MATRIX_OS}-${MATRIX_ARCH}.tar.gz"
           tar czf "${_filename}" "${APPLICATION_NAME}"
           curl --fail --show-error --silent \
             -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
             -H "Content-Type: application/octet-stream" \
             --data-binary @"${_filename}" \
-            "https://uploads.github.com/repos/${{ github.repository }}/releases/${{ needs.create-draft-release.outputs.RELEASE_ID }}/assets?name=${_filename}"
+            "https://uploads.github.com/repos/${GITHUB_REPOSITORY}/releases/${RELEASE_ID}/assets?name=${_filename}"
 
       - name: Compute MSI path (Windows)
         if: startsWith(github.ref, 'refs/tags/') && matrix.os == 'windows' && matrix.tray
         shell: pwsh
+        env:
+          MATRIX_ARCH: ${{ matrix.arch }}
         run: |
-          $cleanVersion = "${{ env.RELEASE_TAG }}" -replace '^v', ''
-          $msiPath = "dist\${{ env.APPLICATION_NAME }}-$cleanVersion-windows-${{ matrix.arch }}.msi"
+          $cleanVersion = $env:RELEASE_TAG -replace '^v', ''
+          $msiPath = "dist\$env:APPLICATION_NAME-$cleanVersion-windows-$env:MATRIX_ARCH.msi"
           "MSI_PATH=$msiPath" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Attest MSI (Windows)
@@ -521,6 +549,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
         with:
           fetch-depth: '0'
+          persist-credentials: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.3.0
       - name: Login to Docker Hub
@@ -578,6 +607,8 @@ jobs:
       packages: write
     runs-on: ubuntu-latest
     steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0 https://github.com/docker/setup-buildx-action/releases/tag/v4.3.0
       - name: Login to Docker Hub
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0 https://github.com/docker/login-action/releases/tag/v4.6.0
         with:
@@ -612,17 +643,13 @@ jobs:
           # Split multi-line TAGS on IFS at runtime; avoids a newline in the script.
           # shellcheck disable=SC2086
           for t in ${TAGS}; do
-            # Extract the underlying manifests from each manifests list and create a new single manifest list.
-            # Word-splitting of the two command substitutions below is intentional:
-            # each digest line becomes a separate argument to `docker manifest create`.
-            # shellcheck disable=SC2046
-            docker manifest create "${t}" \
-              $(docker manifest inspect "${t}-amd64" | jq -r '.manifests[] | .digest' | sed -e "s|^|${t%:*}@|") \
-              $(docker manifest inspect "${t}-arm64" | jq -r '.manifests[] | .digest' | sed -e "s|^|${t%:*}@|")
-            docker manifest push "${t}"
+            # Use buildx imagetools to safely merge multi-arch images and OCI attestations
+            docker buildx imagetools create -t "${t}" "${t}-amd64" "${t}-arm64"
           done
       # Checkout repo so README.md is available for next step
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1 https://github.com/actions/checkout/releases/tag/v7.0.1
+        with:
+          persist-credentials: false
       # Update Docker Hub from README
       - name: Docker Hub Description
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0 https://github.com/peter-evans/dockerhub-description/releases/tag/v5.0.0
@@ -642,6 +669,8 @@ jobs:
     steps:
       - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0 https://github.com/actions/github-script/releases/tag/v9.0.0
         if: startsWith(github.ref, 'refs/tags/')
+        env:
+          RELEASE_ID: ${{ needs.create-draft-release.outputs.RELEASE_ID }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -649,7 +678,8 @@ jobs:
               await github.rest.repos.updateRelease({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                release_id: ${{ needs.create-draft-release.outputs.RELEASE_ID }},
+                // Use radix 10 to parse release ID as a base-10 integer
+                release_id: parseInt(process.env.RELEASE_ID, 10),
                 draft: false,
               });
             } catch (error) {


### PR DESCRIPTION
Fix

```
Created manifest list docker.io/blinklabs/adder:main
manifest docker.io/blinklabs/adder@sha256:a53452a28a83ab4225e1e5d6e076ee1a2b1d33e0408e44551a4520cd202c1b1d must have an OS and Architecture to be pushed to a registry
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Docker manifest creation for multi-arch images by switching from manual manifest lists to `docker buildx imagetools create`, which preserves OCI attestations and resolves the "must have an OS and Architecture" registry error.

- Hardens release asset uploads by moving matrix values and release IDs into environment variables.
- Pins third-party actions to commit SHAs and disables credential persistence in checkout steps.

<sup>Written for commit dfd57a9eee5af3a18c26c56d081abeb2806a6cb8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release workflow reliability by using safer runtime variable handling.
  * Enhanced container image manifest creation for more consistent publishing.
  * Strengthened checkout and build security settings.
* **Chores**
  * Pinned workflow actions to specific versions for more predictable releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->