### PR TITLE
fix: trim whitespace in comma-separated plugin option lists

### DIFF
--- a/filter/cardano/plugin.go
+++ b/filter/cardano/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -88,53 +88,41 @@ func NewFromCmdlineOptions() plugin.Plugin {
 			logging.GetLogger().With("plugin", "filter.cardano"),
 		),
 	}
-	if cmdlineOptions.address != "" {
+	if addresses := plugin.SplitAndTrim(cmdlineOptions.address); len(
+		addresses,
+	) > 0 {
 		pluginOptions = append(
 			pluginOptions,
-			WithAddresses(
-				strings.Split(cmdlineOptions.address, ","),
-			),
+			WithAddresses(addresses),
 		)
 	}
-	if cmdlineOptions.asset != "" {
+	if assets := plugin.SplitAndTrim(cmdlineOptions.asset); len(assets) > 0 {
 		pluginOptions = append(
 			pluginOptions,
-			WithAssetFingerprints(
-				strings.Split(cmdlineOptions.asset, ","),
-			),
+			WithAssetFingerprints(assets),
 		)
 	}
-	if cmdlineOptions.policyId != "" {
+	if policyIds := plugin.SplitAndTrim(cmdlineOptions.policyId); len(
+		policyIds,
+	) > 0 {
 		pluginOptions = append(
 			pluginOptions,
-			WithPolicies(
-				strings.Split(cmdlineOptions.policyId, ","),
-			),
+			WithPolicies(policyIds),
 		)
 	}
-	if cmdlineOptions.poolId != "" {
+	if poolIds := plugin.SplitAndTrim(cmdlineOptions.poolId); len(poolIds) > 0 {
 		pluginOptions = append(
 			pluginOptions,
-			WithPoolIds(
-				strings.Split(cmdlineOptions.poolId, ","),
-			),
+			WithPoolIds(poolIds),
 		)
 	}
-	if cmdlineOptions.drepId != "" {
-		rawIds := strings.Split(cmdlineOptions.drepId, ",")
-		var cleanIds []string
-		for _, id := range rawIds {
-			id = strings.TrimSpace(strings.ToLower(id))
-			if id != "" {
-				cleanIds = append(cleanIds, id)
-			}
-		}
-		if len(cleanIds) > 0 {
-			pluginOptions = append(
-				pluginOptions,
-				WithDRepIds(cleanIds),
-			)
-		}
+	if drepIds := plugin.SplitAndTrim(
+		strings.ToLower(cmdlineOptions.drepId),
+	); len(drepIds) > 0 {
+		pluginOptions = append(
+			pluginOptions,
+			WithDRepIds(drepIds),
+		)
 	}
 	p := New(pluginOptions...)
 	return p

--- a/filter/cardano/plugin_options_test.go
+++ b/filter/cardano/plugin_options_test.go
@@ -1,0 +1,147 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cardano
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// withCmdlineOptions sets the package-level options for the duration of a
+// test and restores the previous values afterwards
+func withCmdlineOptions(t *testing.T, apply func()) {
+	t.Helper()
+	orig := cmdlineOptions
+	t.Cleanup(func() { cmdlineOptions = orig })
+	cmdlineOptions = struct {
+		address  string
+		asset    string
+		policyId string
+		poolId   string
+		drepId   string
+	}{}
+	apply()
+}
+
+func TestNewFromCmdlineOptionsTrimsAddresses(t *testing.T) {
+	withCmdlineOptions(t, func() {
+		// As produced by a YAML folded block scalar (>-)
+		cmdlineOptions.address = "addr1aaa, addr1bbb, stake1ccc"
+	})
+	c, ok := NewFromCmdlineOptions().(*Cardano)
+	assert.True(t, ok, "plugin should be a *Cardano")
+	assert.True(t, c.filterSet.hasAddressFilter)
+	assert.Equal(
+		t,
+		map[string]struct{}{
+			"addr1aaa": {},
+			"addr1bbb": {},
+		},
+		c.filterSet.addresses.paymentAddresses,
+	)
+	assert.Equal(
+		t,
+		map[string]struct{}{"stake1ccc": {}},
+		c.filterSet.addresses.stakeAddresses,
+	)
+}
+
+func TestNewFromCmdlineOptionsTrimsAssets(t *testing.T) {
+	withCmdlineOptions(t, func() {
+		cmdlineOptions.asset = "asset1aaa,\n asset1bbb"
+	})
+	c, ok := NewFromCmdlineOptions().(*Cardano)
+	assert.True(t, ok, "plugin should be a *Cardano")
+	assert.True(t, c.filterSet.hasAssetFilter)
+	assert.Equal(
+		t,
+		map[string]struct{}{
+			"asset1aaa": {},
+			"asset1bbb": {},
+		},
+		c.filterSet.assets.fingerprints,
+	)
+}
+
+func TestNewFromCmdlineOptionsTrimsPolicies(t *testing.T) {
+	withCmdlineOptions(t, func() {
+		cmdlineOptions.policyId = "policy1, policy2"
+	})
+	c, ok := NewFromCmdlineOptions().(*Cardano)
+	assert.True(t, ok, "plugin should be a *Cardano")
+	assert.True(t, c.filterSet.hasPolicyFilter)
+	assert.Equal(
+		t,
+		map[string]struct{}{
+			"policy1": {},
+			"policy2": {},
+		},
+		c.filterSet.policies.policyIds,
+	)
+}
+
+func TestNewFromCmdlineOptionsTrimsPoolIds(t *testing.T) {
+	const (
+		poolA = "00000000000000000000000000000000000000000000000000000001"
+		poolB = "00000000000000000000000000000000000000000000000000000002"
+	)
+	withCmdlineOptions(t, func() {
+		cmdlineOptions.poolId = poolA + ", " + poolB
+	})
+	c, ok := NewFromCmdlineOptions().(*Cardano)
+	assert.True(t, ok, "plugin should be a *Cardano")
+	assert.True(t, c.filterSet.hasPoolFilter)
+	assert.Equal(
+		t,
+		map[string]struct{}{
+			poolA: {},
+			poolB: {},
+		},
+		c.filterSet.pools.hexPoolIds,
+	)
+}
+
+func TestNewFromCmdlineOptionsTrimsDRepIds(t *testing.T) {
+	const drepId = "00000000000000000000000000000000000000000000000000000003"
+	withCmdlineOptions(t, func() {
+		// Mixed case plus whitespace: both must be normalized
+		cmdlineOptions.drepId = " " + drepId + ",\n ABCDEF" +
+			"00000000000000000000000000000000000000000000000004"
+	})
+	c, ok := NewFromCmdlineOptions().(*Cardano)
+	assert.True(t, ok, "plugin should be a *Cardano")
+	assert.True(t, c.filterSet.hasDRepFilter)
+	assert.Equal(
+		t,
+		map[string]struct{}{
+			drepId: {},
+			"abcdef00000000000000000000000000000000000000000000000004": {},
+		},
+		c.filterSet.dreps.hexDRepIds,
+	)
+}
+
+// A single address with leading whitespace must still match, as reported in
+// blinklabs-io/adder#815
+func TestNewFromCmdlineOptionsTrimsSingleAddress(t *testing.T) {
+	withCmdlineOptions(t, func() {
+		cmdlineOptions.address = " addr1aaa"
+	})
+	c, ok := NewFromCmdlineOptions().(*Cardano)
+	assert.True(t, ok, "plugin should be a *Cardano")
+	_, exists := c.filterSet.addresses.paymentAddresses["addr1aaa"]
+	assert.True(t, exists, "address should be stored without leading space")
+}

--- a/filter/event/plugin.go
+++ b/filter/event/plugin.go
@@ -15,8 +15,6 @@
 package event
 
 import (
-	"strings"
-
 	"github.com/blinklabs-io/adder/internal/logging"
 	"github.com/blinklabs-io/adder/plugin"
 )
@@ -52,12 +50,12 @@ func NewFromCmdlineOptions() plugin.Plugin {
 			logging.GetLogger().With("plugin", "filter.event"),
 		),
 	}
-	if cmdlineOptions.eventType != "" {
+	if eventTypes := plugin.SplitAndTrim(
+		cmdlineOptions.eventType,
+	); len(eventTypes) > 0 {
 		pluginOptions = append(
 			pluginOptions,
-			WithTypes(
-				strings.Split(cmdlineOptions.eventType, ","),
-			),
+			WithTypes(eventTypes),
 		)
 	}
 	p := New(pluginOptions...)

--- a/filter/event/plugin_test.go
+++ b/filter/event/plugin_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package event
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// setEventType sets the package-level option for the duration of a test and
+// restores the previous value afterwards
+func setEventType(t *testing.T, val string) {
+	t.Helper()
+	orig := cmdlineOptions.eventType
+	t.Cleanup(func() { cmdlineOptions.eventType = orig })
+	cmdlineOptions.eventType = val
+}
+
+func TestNewFromCmdlineOptionsEventTypes(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "no whitespace",
+			input:    "block,transaction",
+			expected: []string{"block", "transaction"},
+		},
+		{
+			name:     "YAML folded scalar (spaces after commas)",
+			input:    "block, transaction, rollback",
+			expected: []string{"block", "transaction", "rollback"},
+		},
+		{
+			name:     "YAML literal scalar (newlines and tabs)",
+			input:    "block,\n\ttransaction\n",
+			expected: []string{"block", "transaction"},
+		},
+		{
+			// A folded scalar only replaces newlines with spaces for equally
+			// indented lines; a more-indented line keeps its newline and
+			// leading indent
+			name:     "YAML folded scalar (more-indented line)",
+			input:    "block,\n  transaction,\nrollback",
+			expected: []string{"block", "transaction", "rollback"},
+		},
+		{
+			name:     "single type with leading space",
+			input:    " block",
+			expected: []string{"block"},
+		},
+		{
+			name:     "empty entries dropped",
+			input:    "block,,  ,transaction,",
+			expected: []string{"block", "transaction"},
+		},
+		{
+			name:     "whitespace only leaves filter unset",
+			input:    "  ,\n ",
+			expected: nil,
+		},
+		{
+			name:     "empty leaves filter unset",
+			input:    "",
+			expected: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			setEventType(t, testCase.input)
+			e, ok := NewFromCmdlineOptions().(*Event)
+			assert.True(t, ok, "plugin should be an *Event")
+			assert.Equal(t, testCase.expected, e.filterTypes)
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/blinklabs-io/adder
 
-go 1.25.7
+go 1.26.0
 
 require (
 	connectrpc.com/connect v1.20.0

--- a/input/chainsync/plugin.go
+++ b/input/chainsync/plugin.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -143,8 +143,8 @@ func NewFromCmdlineOptions() plugin.Plugin {
 		WithAutoReconnect(cmdlineOptions.autoReconnect),
 		WithDelayConfirmations(cmdlineOptions.delayConfirmations),
 	}
-	if cmdlineOptions.intersectPoint != "" {
-		pointsSlice := strings.Split(cmdlineOptions.intersectPoint, ",")
+	pointsSlice := plugin.SplitAndTrim(cmdlineOptions.intersectPoint)
+	if len(pointsSlice) > 0 {
 		intersectPoints := make([]ocommon.Point, 0, len(pointsSlice))
 		for _, point := range pointsSlice {
 			intersectPointParts := strings.Split(point, ".")

--- a/input/chainsync/plugin_test.go
+++ b/input/chainsync/plugin_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Blink Labs Software
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package chainsync
+
+import (
+	"encoding/hex"
+	"fmt"
+	"testing"
+
+	ocommon "github.com/blinklabs-io/gouroboros/protocol/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	testHashA = "0000000000000000000000000000000000000000000000000000000000000001"
+	testHashB = "0000000000000000000000000000000000000000000000000000000000000002"
+)
+
+// setIntersectPoint sets the package-level option for the duration of a test
+// and restores the previous value afterwards
+func setIntersectPoint(t *testing.T, val string) {
+	t.Helper()
+	orig := cmdlineOptions.intersectPoint
+	t.Cleanup(func() { cmdlineOptions.intersectPoint = orig })
+	cmdlineOptions.intersectPoint = val
+}
+
+func mustPoint(t *testing.T, slot uint64, hash string) ocommon.Point {
+	t.Helper()
+	hashBytes, err := hex.DecodeString(hash)
+	require.NoError(t, err)
+	return ocommon.Point{Slot: slot, Hash: hashBytes}
+}
+
+func TestNewFromCmdlineOptionsIntersectPoints(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []ocommon.Point
+	}{
+		{
+			name:  "no whitespace",
+			input: "1." + testHashA + ",2." + testHashB,
+		},
+		{
+			name:  "YAML folded scalar (spaces after commas)",
+			input: "1." + testHashA + ", 2." + testHashB,
+		},
+		{
+			name:  "YAML literal scalar (newlines and tabs)",
+			input: "1." + testHashA + ",\n\t2." + testHashB + "\n",
+		},
+		{
+			// A folded scalar only replaces newlines with spaces for equally
+			// indented lines; a more-indented line keeps its newline and
+			// leading indent
+			name:  "YAML folded scalar (more-indented line)",
+			input: "1." + testHashA + ",\n  2." + testHashB,
+		},
+		{
+			name:  "empty entries dropped",
+			input: "1." + testHashA + ",,  ,2." + testHashB + ",",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			setIntersectPoint(t, testCase.input)
+			p := NewFromCmdlineOptions()
+			require.NotNil(t, p, "plugin should be created")
+			c, ok := p.(*ChainSync)
+			require.True(t, ok, "plugin should be a *ChainSync")
+			assert.Equal(
+				t,
+				[]ocommon.Point{
+					mustPoint(t, 1, testHashA),
+					mustPoint(t, 2, testHashB),
+				},
+				c.intersectPoints,
+			)
+		})
+	}
+}
+
+// A single intersect point with leading whitespace must still parse
+func TestNewFromCmdlineOptionsIntersectPointLeadingSpace(t *testing.T) {
+	setIntersectPoint(t, " 1."+testHashA)
+	p := NewFromCmdlineOptions()
+	require.NotNil(t, p, "plugin should be created")
+	c, ok := p.(*ChainSync)
+	require.True(t, ok, "plugin should be a *ChainSync")
+	assert.Equal(
+		t,
+		[]ocommon.Point{mustPoint(t, 1, testHashA)},
+		c.intersectPoints,
+	)
+}
+
+// Malformed points are still a hard error, not silently skipped
+func TestNewFromCmdlineOptionsIntersectPointInvalid(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+	}{
+		{name: "missing hash", input: "1"},
+		{name: "non-numeric slot", input: "abc." + testHashA},
+		{name: "invalid hex hash", input: "1.zzzz"},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			setIntersectPoint(t, testCase.input)
+			assert.Nil(
+				t,
+				NewFromCmdlineOptions(),
+				"invalid intersect point should not yield a plugin",
+			)
+		})
+	}
+}
+
+// A value that trims away to nothing must fall back to the intersect-tip
+// behaviour, exactly as an unset value does. Treating it as "zero intersect
+// points" instead would silently sync from genesis.
+func TestNewFromCmdlineOptionsIntersectPointWhitespaceOnly(t *testing.T) {
+	origTip := cmdlineOptions.intersectTip
+	t.Cleanup(func() { cmdlineOptions.intersectTip = origTip })
+	cmdlineOptions.intersectTip = true
+
+	for _, input := range []string{"", "  ,\n ", ","} {
+		t.Run(fmt.Sprintf("%q", input), func(t *testing.T) {
+			setIntersectPoint(t, input)
+			p := NewFromCmdlineOptions()
+			require.NotNil(t, p, "plugin should be created")
+			c, ok := p.(*ChainSync)
+			require.True(t, ok, "plugin should be a *ChainSync")
+			assert.Empty(t, c.intersectPoints)
+			assert.True(
+				t,
+				c.intersectTip,
+				"should fall back to intersect-tip, not genesis",
+			)
+		})
+	}
+}

--- a/plugin/option.go
+++ b/plugin/option.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Blink Labs Software
+// Copyright 2026 Blink Labs Software
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -40,6 +40,19 @@ type PluginOption struct {
 	CustomFlag   string
 	Description  string
 	Type         PluginOptionType
+}
+
+// SplitAndTrim splits a comma-separated option value, trimming surrounding
+// whitespace from each entry and dropping empty ones. YAML folded/literal
+// block scalars introduce spaces and newlines around entries.
+func SplitAndTrim(val string) []string {
+	var out []string
+	for item := range strings.SplitSeq(val, ",") {
+		if item = strings.TrimSpace(item); item != "" {
+			out = append(out, item)
+		}
+	}
+	return out
 }
 
 func (p *PluginOption) AddToFlagSet(

--- a/plugin/option_test.go
+++ b/plugin/option_test.go
@@ -375,3 +375,91 @@ func TestProcessConfigUnknownType(t *testing.T) {
 		t.Fatal("expected error for unknown type, got nil")
 	}
 }
+
+// TestSplitAndTrim verifies comma-separated option values are split with
+// surrounding whitespace removed and empty entries dropped, including the
+// separator forms produced by YAML block scalars.
+func TestSplitAndTrim(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: nil,
+		},
+		{
+			name:     "no separator",
+			input:    "addr1aaa",
+			expected: []string{"addr1aaa"},
+		},
+		{
+			name:     "no whitespace",
+			input:    "addr1aaa,addr1bbb",
+			expected: []string{"addr1aaa", "addr1bbb"},
+		},
+		{
+			name:  "YAML folded scalar (spaces after commas)",
+			input: "addr1aaa, addr1bbb, addr1ccc",
+			expected: []string{
+				"addr1aaa",
+				"addr1bbb",
+				"addr1ccc",
+			},
+		},
+		{
+			name:     "YAML literal scalar (newlines and tabs)",
+			input:    "addr1aaa,\n\taddr1bbb\n",
+			expected: []string{"addr1aaa", "addr1bbb"},
+		},
+		{
+			// A folded scalar only replaces newlines with spaces for equally
+			// indented lines; a more-indented line keeps its newline and
+			// leading indent
+			name:  "YAML folded scalar (more-indented line)",
+			input: "addr1aaa,\n  addr1bbb,\naddr1ccc",
+			expected: []string{
+				"addr1aaa",
+				"addr1bbb",
+				"addr1ccc",
+			},
+		},
+		{
+			// A blank line inside a folded scalar also yields a newline
+			name:     "YAML folded scalar (blank line)",
+			input:    "addr1aaa,\naddr1bbb",
+			expected: []string{"addr1aaa", "addr1bbb"},
+		},
+		{
+			name:     "leading and trailing whitespace",
+			input:    "  addr1aaa  ",
+			expected: []string{"addr1aaa"},
+		},
+		{
+			name:     "empty entries dropped",
+			input:    "addr1aaa,,  ,addr1bbb,",
+			expected: []string{"addr1aaa", "addr1bbb"},
+		},
+		{
+			name:     "whitespace only",
+			input:    "  ,\n , ",
+			expected: nil,
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := SplitAndTrim(testCase.input)
+			if len(got) != len(testCase.expected) {
+				t.Fatalf("got %q, want %q", got, testCase.expected)
+			}
+			for i := range got {
+				if got[i] != testCase.expected[i] {
+					t.Errorf("got %q, want %q", got, testCase.expected)
+					break
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
YAML folded/literal block scalars leave whitespace after each comma, so every entry after the first kept a leading space, newline or indent. Cardano and event filters silently never matched; chainsync was worse, the untrimmed slot failed to parse and dropped the input plugin.

Add plugin.SplitAndTrim, trimming each entry and dropping empty ones. Use it for cardano addresses, assets, policies, pools and DReps, event types, and chainsync intersect points. Filters enable only when an entry survives. Malformed intersect points remain a hard error.

Gate the chainsync branch on the trimmed count, not the raw string, so a value that trims to nothing falls back to intersect-tip instead of silently syncing from genesis.

All three config sources write the same PluginOption.Dest and are read only in NewFromCmdlineOptions, so this covers every path. Embedded users of the With* funcs pass []string and are unaffected.

Also bump the go directive to 1.26.0; CI already runs 1.26.x.

Verified clean: build, vet, mod verify, test -race, golangci-lint run, golangci-lint fmt, gofmt, golines, nilaway.

Fixes #815

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes comma-separated plugin options so YAML folded/literal block scalars no longer leave whitespace on every entry after the first. Cardano and event filters silently never matched before, and chainsync's untrimmed slot failed to parse and dropped the input plugin.

**Bug Fixes**
- Adds `plugin.SplitAndTrim`, which trims each entry and drops empty ones, and applies it to cardano addresses, assets, policies, pools, and DReps, event types, and chainsync intersect points.
- Chainsync now branches on the trimmed count, so a value that trims to nothing falls back to intersect-tip instead of silently syncing from genesis; malformed intersect points stay a hard error.
- Bumps the go directive to 1.26.0; CI already runs 1.26.x.

<sup>Written for commit 31c3af66b45ac6a6dd066bca1f1d86c2ad2140bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of comma-separated filter and event options, consistently trimming whitespace and ignoring empty entries.
  - Normalized DRep IDs to lowercase for more reliable matching.
  - Improved chainsync intersect-point handling, including whitespace-only values and malformed point errors.
  - Preserved fallback behavior when no valid intersect points are provided.

- **Tests**
  - Added coverage for varied spacing, line breaks, empty entries, casing, invalid values, and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->