### PR TITLE
ci: fix unresolvable msys2/setup-msys2 pin

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -117,7 +117,7 @@ jobs:
       - name: Set up MSYS2 MinGW64 for Windows amd64 CGO
         if: matrix.os == 'windows' && matrix.arch == 'amd64' && matrix.tray
         id: msys2-amd64
-        uses: msys2/setup-msys2@66cd2cc13f75153731901cda3aeead6c28c9fbc4 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: MINGW64
           update: true
@@ -127,7 +127,7 @@ jobs:
       - name: Set up MSYS2 clangarm64 for Windows arm64 CGO
         if: matrix.os == 'windows' && matrix.arch == 'arm64' && matrix.tray
         id: msys2-arm64
-        uses: msys2/setup-msys2@66cd2cc13f75153731901cda3aeead6c28c9fbc4 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: CLANGARM64
           update: true

--- a/.github/workflows/test-msi.yml
+++ b/.github/workflows/test-msi.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up MSYS2 MinGW64 (amd64 CGO for Fyne)
         if: env.WINDOWS_ARCH == 'amd64'
         id: msys2-amd64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: MINGW64
           update: true
@@ -49,7 +49,7 @@ jobs:
       - name: Set up MSYS2 CLANGARM64 (arm64 CGO for Fyne)
         if: env.WINDOWS_ARCH == 'arm64'
         id: msys2-arm64
-        uses: msys2/setup-msys2@v2
+        uses: msys2/setup-msys2@66cd2cce69caa17b53920067426061ca1de3a884 # v2.32.0 https://github.com/msys2/setup-msys2/releases/tag/v2.32.0
         with:
           msystem: CLANGARM64
           update: true


### PR DESCRIPTION
The v2.32.0 pin in publish.yml was `66cd2cc`_13f75153731901cda3aeead6c28c9fbc4_, which does not exist upstream, so the Windows CGO steps failed with "unable to resolve action". Only publish.yml runs on tag push, so the break surfaced at release time rather than on the PR that added it.

The real v2.32.0 commit is `66cd2cc`_e69caa17b53920067426061ca1de3a884_.
```
https://github.com/msys2/setup-msys2/commit/66cd2cce69caa17b53920067426061ca1de3a884
```

Also pin the two test-msi.yml refs, which used the mutable @v2 tag, to the same commit.

Verified every SHA-pinned action in .github resolves upstream and matches its version comment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the unresolvable `msys2/setup-msys2` pin in `publish.yml` and pins the mutable `@v2` references in `test-msi.yml` to the same valid v2.32.0 commit.

- The previous pin was an invalid SHA that made Windows CGO steps fail; the break only surfaced at release time because `publish.yml` runs on tag push.
- Verified every SHA-pinned action in `.github` resolves upstream and matches its version comment.

<sup>Written for commit eb9f42301e0d2313e8f980e5496e8842b4f58b80. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/blinklabs-io/adder/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Windows build and packaging workflows to use a newer, fixed version of the MSYS2 setup action.
  * Improved consistency and reliability across amd64 and arm64 Windows builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->